### PR TITLE
Peaks nomenclature review

### DIFF
--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -251,28 +251,28 @@ def test_distance():
     np.testing.assert_almost_equal(distance(noiseWave), 1007.8711901383033, decimal=5)
 
 
-def test_minpeaks():
-    np.testing.assert_almost_equal(minpeaks(const0), 0.0)
-    np.testing.assert_almost_equal(minpeaks(const1), 0.0)
-    np.testing.assert_almost_equal(minpeaks(constNeg), 0.0)
-    np.testing.assert_almost_equal(minpeaks(constF), 0.0)
-    np.testing.assert_almost_equal(minpeaks(lin), 0.0)
-    np.testing.assert_almost_equal(minpeaks(lin0), 0.0, decimal=5)
-    np.testing.assert_almost_equal(minpeaks(wave), 5, decimal=5)
-    np.testing.assert_almost_equal(minpeaks(offsetWave), 5, decimal=5)
-    np.testing.assert_almost_equal(minpeaks(noiseWave), 323, decimal=5)
+def test_negative_turning():
+    np.testing.assert_almost_equal(negative_turning(const0), 0.0)
+    np.testing.assert_almost_equal(negative_turning(const1), 0.0)
+    np.testing.assert_almost_equal(negative_turning(constNeg), 0.0)
+    np.testing.assert_almost_equal(negative_turning(constF), 0.0)
+    np.testing.assert_almost_equal(negative_turning(lin), 0.0)
+    np.testing.assert_almost_equal(negative_turning(lin0), 0.0, decimal=5)
+    np.testing.assert_almost_equal(negative_turning(wave), 5, decimal=5)
+    np.testing.assert_almost_equal(negative_turning(offsetWave), 5, decimal=5)
+    np.testing.assert_almost_equal(negative_turning(noiseWave), 323, decimal=5)
 
 
-def test_maxpeaks():
-    np.testing.assert_almost_equal(maxpeaks(const0), 0.0)
-    np.testing.assert_almost_equal(maxpeaks(const1), 0.0)
-    np.testing.assert_almost_equal(maxpeaks(constNeg), 0.0)
-    np.testing.assert_almost_equal(maxpeaks(constF), 0.0)
-    np.testing.assert_almost_equal(maxpeaks(lin), 0.0)
-    np.testing.assert_almost_equal(maxpeaks(lin0), 0.0, decimal=5)
-    np.testing.assert_almost_equal(maxpeaks(wave), 5, decimal=5)
-    np.testing.assert_almost_equal(maxpeaks(offsetWave), 5, decimal=5)
-    np.testing.assert_almost_equal(maxpeaks(noiseWave), 322, decimal=5)
+def test_positive_turning():
+    np.testing.assert_almost_equal(positive_turning(const0), 0.0)
+    np.testing.assert_almost_equal(positive_turning(const1), 0.0)
+    np.testing.assert_almost_equal(positive_turning(constNeg), 0.0)
+    np.testing.assert_almost_equal(positive_turning(constF), 0.0)
+    np.testing.assert_almost_equal(positive_turning(lin), 0.0)
+    np.testing.assert_almost_equal(positive_turning(lin0), 0.0, decimal=5)
+    np.testing.assert_almost_equal(positive_turning(wave), 5, decimal=5)
+    np.testing.assert_almost_equal(positive_turning(offsetWave), 5, decimal=5)
+    np.testing.assert_almost_equal(positive_turning(noiseWave), 322, decimal=5)
 
 
 def test_centroid():
@@ -614,16 +614,16 @@ def test_spect_variation():
     np.testing.assert_almost_equal(spectral_variation(noiseWave, Fs), 0.9775968083533805, decimal=5)
 
 
-def test_spectral_maxpeaks():
-    np.testing.assert_almost_equal(spectral_maxpeaks(const0, Fs), 0.0)
-    np.testing.assert_almost_equal(spectral_maxpeaks(const1, Fs), 0.0)
-    np.testing.assert_almost_equal(spectral_maxpeaks(constNeg, Fs), 0.0)
-    np.testing.assert_almost_equal(spectral_maxpeaks(constF, Fs), 0.0)
-    np.testing.assert_almost_equal(spectral_maxpeaks(lin, Fs), 0.0)
-    np.testing.assert_almost_equal(spectral_maxpeaks(lin0, Fs), 1.0, decimal=5)
-    np.testing.assert_almost_equal(spectral_maxpeaks(wave, Fs), 157, decimal=0)
-    np.testing.assert_almost_equal(spectral_maxpeaks(offsetWave, Fs), 161, decimal=1)
-    np.testing.assert_almost_equal(spectral_maxpeaks(noiseWave, Fs), 172.0, decimal=1)
+def test_spectral_positive_turning():
+    np.testing.assert_almost_equal(spectral_positive_turning(const0, Fs), 0.0)
+    np.testing.assert_almost_equal(spectral_positive_turning(const1, Fs), 0.0)
+    np.testing.assert_almost_equal(spectral_positive_turning(constNeg, Fs), 0.0)
+    np.testing.assert_almost_equal(spectral_positive_turning(constF, Fs), 0.0)
+    np.testing.assert_almost_equal(spectral_positive_turning(lin, Fs), 0.0)
+    np.testing.assert_almost_equal(spectral_positive_turning(lin0, Fs), 1.0, decimal=5)
+    np.testing.assert_almost_equal(spectral_positive_turning(wave, Fs), 157, decimal=0)
+    np.testing.assert_almost_equal(spectral_positive_turning(offsetWave, Fs), 161, decimal=1)
+    np.testing.assert_almost_equal(spectral_positive_turning(noiseWave, Fs), 172.0, decimal=1)
 
 
 def test_human_range_energy():

--- a/tsfel/feature_extraction/features.json
+++ b/tsfel/feature_extraction/features.json
@@ -132,10 +132,10 @@
       },
       "use": "yes"
     },
-    "Spectral maximum peaks": {
+    "Spectral positive turning points": {
       "complexity": "log",
-      "description": "Computes the number of maximum spectral peaks.",
-      "function": "tsfel.spectral_maxpeaks",
+      "description": "Computes number of positive turning points of the fft magnitude signal",
+      "function": "tsfel.spectral_positive_turning",
       "parameters": {
         "fs": 100
       },
@@ -421,10 +421,10 @@
       },
       "use": "yes"
     },
-    "Maximum peaks": {
+    "Positive turning points": {
       "complexity": "constant",
-      "description": "Computes number of maximum peaks of the signal.",
-      "function": "tsfel.maxpeaks",
+      "description": "Computes number of positive turning points of the signal.",
+      "function": "tsfel.positive_turning",
       "parameters": "",
       "use": "yes"
     },
@@ -456,10 +456,10 @@
       "parameters": "",
       "use": "yes"
     },
-    "Minimum peaks": {
+    "Negative turning points": {
       "complexity": "constant",
-      "description": "Computes number of minimum peaks of the signal.",
-      "function": "tsfel.minpeaks",
+      "description": "Computes number of negative turning points of the signal.",
+      "function": "tsfel.negative_turning",
       "parameters": "",
       "use": "yes"
     },

--- a/tsfel/feature_extraction/features.py
+++ b/tsfel/feature_extraction/features.py
@@ -62,52 +62,52 @@ def calc_centroid(signal, fs):
 
 
 @set_domain("domain", "temporal")
-def minpeaks(signal):
-    """Computes number of minimum peaks of the signal.
+def negative_turning(signal):
+    """Computes number of negative turning points of the signal.
 
     Feature computational cost: 1
 
     Parameters
     ----------
     signal : nd-array
-        Input from which minimum number of peaks is counted
+        Input from which minimum number of negative turning points are counted
     Returns
     -------
     float
-        Minimum number of peaks
+        Number of negative turning points
 
     """
     diff_sig = np.diff(signal)
     array_signal = np.arange(len(diff_sig[:-1]))
-    min_peaks = np.where((diff_sig[array_signal] < 0) & (diff_sig[array_signal+1] > 0))[0]
+    negative_turning_pts = np.where((diff_sig[array_signal] < 0) & (diff_sig[array_signal+1] > 0))[0]
 
-    return len(min_peaks)
+    return len(negative_turning_pts)
 
 
 @set_domain("domain", "temporal")
-def maxpeaks(signal):
-    """Computes number of maximum peaks of the signal.
+def positive_turning(signal):
+    """Computes number of positive turning points of the signal.
 
     Feature computational cost: 1
 
     Parameters
     ----------
     signal : nd-array
-        Input from which maximum number of peaks is counted
+        Input from which  positive turning points are counted
 
     Returns
     -------
     float
-        Maximum number of peaks
+        Number of positive turning points
 
     """
     diff_sig = np.diff(signal)
 
     array_signal = np.arange(len(diff_sig[:-1]))
 
-    max_peaks = np.where((diff_sig[array_signal+1] < 0) & (diff_sig[array_signal] > 0))[0]
+    positive_turning_pts = np.where((diff_sig[array_signal+1] < 0) & (diff_sig[array_signal] > 0))[0]
 
-    return len(max_peaks)
+    return len(positive_turning_pts)
 
 
 @set_domain("domain", "temporal")
@@ -1228,22 +1228,22 @@ def spectral_variation(signal, fs):
 
 
 @set_domain("domain", "spectral")
-def spectral_maxpeaks(signal, fs):
-    """Computes number of maximum spectral peaks of the signal.
+def spectral_positive_turning(signal, fs):
+    """Computes number of positive turning points of the fft magnitude signal.
 
     Feature computational cost: 1
 
     Parameters
     ----------
     signal : nd-array
-        Input from which the number of maximum spectral peaks is computed
+        Input from which the number of positive turning points of the fft magnitude are computed
     fs : int
         Sampling frequency
 
     Returns
     -------
     float
-        Total number of maximum spectral peaks
+        Number of positive turning points
 
     """
     f, fmag = calc_fft(signal, fs)
@@ -1251,9 +1251,10 @@ def spectral_maxpeaks(signal, fs):
 
     array_signal = np.arange(len(diff_sig[:-1]))
 
-    max_s_peaks = np.where((diff_sig[array_signal+1] < 0) & (diff_sig[array_signal] > 0))[0]
+    positive_turning_pts = np.where((diff_sig[array_signal+1] < 0) & (diff_sig[array_signal] > 0))[0]
 
-    return len(max_s_peaks)
+    return len(positive_turning_pts)
+
 
 @set_domain("domain", "spectral")
 def spectral_roll_off(signal, fs):


### PR DESCRIPTION
Peaks nomenclature review:
 - maxpeaks, minpeaks and spectral_maxpeaks are not the detection of peaks but the detection of turning points (or inflection points).

maxpeaks - positive turning points count (new nomenclature: positive_turning)
minpeaks - negative turning points count (new nomenclature: negative_turning)
spectral_maxpeaks - positive turning points count of fft magnitude (new nomenclature: spectral_positive_turning)

(The Features_dev sheet is not yet updated for avoiding conflicts with further PRs)