### PR TITLE
Removing window spliter

### DIFF
--- a/notebooks/TSFEL_HAR_Example.ipynb
+++ b/notebooks/TSFEL_HAR_Example.ipynb
@@ -150,7 +150,7 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 458.0
+     "height": 458
     },
     "colab_type": "code",
     "id": "EK66Oc_jNzKc",
@@ -218,7 +218,7 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 221.0
+     "height": 221
     },
     "colab_type": "code",
     "id": "uf_qta_DJ4xD",
@@ -254,7 +254,7 @@
       ]
      },
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
@@ -287,7 +287,7 @@
       ]
      },
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
@@ -374,7 +374,7 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 252.0
+     "height": 252
     },
     "colab_type": "code",
     "id": "E3o5jF_sOwDI",
@@ -422,7 +422,7 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 380.0
+     "height": 380
     },
     "colab_type": "code",
     "id": "6lhdbQnCQxSV",

--- a/notebooks/TSFEL_HAR_Example.ipynb
+++ b/notebooks/TSFEL_HAR_Example.ipynb
@@ -150,7 +150,7 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 458
+     "height": 458.0
     },
     "colab_type": "code",
     "id": "EK66Oc_jNzKc",
@@ -218,7 +218,7 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 221
+     "height": 221.0
     },
     "colab_type": "code",
     "id": "uf_qta_DJ4xD",
@@ -254,7 +254,7 @@
       ]
      },
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     },
     {
      "name": "stdout",
@@ -287,7 +287,7 @@
       ]
      },
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     },
     {
      "name": "stdout",
@@ -374,7 +374,7 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 252
+     "height": 252.0
     },
     "colab_type": "code",
     "id": "E3o5jF_sOwDI",
@@ -422,7 +422,7 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 380
+     "height": 380.0
     },
     "colab_type": "code",
     "id": "6lhdbQnCQxSV",

--- a/notebooks/TSFEL_SMARTWATCH_HAR_Example.ipynb
+++ b/notebooks/TSFEL_SMARTWATCH_HAR_Example.ipynb
@@ -337,19 +337,19 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 221.0
+     "height": 221
     },
     "colab_type": "code",
     "executionInfo": {
-     "elapsed": 482236.0,
+     "elapsed": 482236,
      "status": "ok",
-     "timestamp": 1.586778157434E12,
+     "timestamp": 1586778157434,
      "user": {
       "displayName": "Leticia Fernandes",
       "photoUrl": "https://lh3.googleusercontent.com/a-/AOh14Gj3U_hSW1M2-Ab0tHYcZEiOzvFIfJrkA-pccFhU=s64",
       "userId": "17109198128714142667"
      },
-     "user_tz": -60.0
+     "user_tz": -60
     },
     "id": "NHr4OvvXC8ax",
     "outputId": "a4b80acf-92f2-4d63-af62-d3348798cdd0"
@@ -384,7 +384,7 @@
       ]
      },
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
@@ -417,7 +417,7 @@
       ]
      },
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
@@ -463,19 +463,19 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 54.0
+     "height": 54
     },
     "colab_type": "code",
     "executionInfo": {
-     "elapsed": 1589.0,
+     "elapsed": 1589,
      "status": "ok",
-     "timestamp": 1.586778213672E12,
+     "timestamp": 1586778213672,
      "user": {
       "displayName": "Leticia Fernandes",
       "photoUrl": "https://lh3.googleusercontent.com/a-/AOh14Gj3U_hSW1M2-Ab0tHYcZEiOzvFIfJrkA-pccFhU=s64",
       "userId": "17109198128714142667"
      },
-     "user_tz": -60.0
+     "user_tz": -60
     },
     "id": "sPGaYs0Qx0z3",
     "outputId": "5b1ec961-2752-4795-934a-50647b0f8d51"
@@ -597,19 +597,19 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 796.0
+     "height": 796
     },
     "colab_type": "code",
     "executionInfo": {
-     "elapsed": 14133.0,
+     "elapsed": 14133,
      "status": "ok",
-     "timestamp": 1.586778235659E12,
+     "timestamp": 1586778235659,
      "user": {
       "displayName": "Leticia Fernandes",
       "photoUrl": "https://lh3.googleusercontent.com/a-/AOh14Gj3U_hSW1M2-Ab0tHYcZEiOzvFIfJrkA-pccFhU=s64",
       "userId": "17109198128714142667"
      },
-     "user_tz": -60.0
+     "user_tz": -60
     },
     "id": "dxQJwbedb2wQ",
     "outputId": "87c0e05a-13bb-4b83-a2db-043587a9f38f"

--- a/notebooks/TSFEL_SMARTWATCH_HAR_Example.ipynb
+++ b/notebooks/TSFEL_SMARTWATCH_HAR_Example.ipynb
@@ -278,7 +278,7 @@
     "        # Only one acquisition of act\n",
     "        if (len(ids_act_gyro) == 1) and (len(ids_act_acc) == 1):\n",
     "            data = pre_process_data(acc_data_act, gyro_data_act, fs)\n",
-    "            w = tsfel.signal_window_spliter(data.astype(float), ws, overlap) \n",
+    "            w = tsfel.signal_window_splitter(data.astype(float), ws, overlap) \n",
     "            windows.append(w)\n",
     "            labels.append(np.repeat(act, len(w)))\n",
     "        else:\n",
@@ -288,7 +288,7 @@
     "\n",
     "            for acc_data_act, gyro_data_act in zip(acc_data_acts, gyro_data_acts):\n",
     "                data = pre_process_data(acc_data_act, gyro_data_act, fs)\n",
-    "                w = tsfel.signal_window_spliter(data.astype(float), ws, overlap)   \n",
+    "                w = tsfel.signal_window_splitter(data.astype(float), ws, overlap)   \n",
     "                windows.append(w)\n",
     "                labels.append(np.repeat(act, len(w)))\n",
     "\n",
@@ -337,19 +337,19 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 221
+     "height": 221.0
     },
     "colab_type": "code",
     "executionInfo": {
-     "elapsed": 482236,
+     "elapsed": 482236.0,
      "status": "ok",
-     "timestamp": 1586778157434,
+     "timestamp": 1.586778157434E12,
      "user": {
       "displayName": "Leticia Fernandes",
       "photoUrl": "https://lh3.googleusercontent.com/a-/AOh14Gj3U_hSW1M2-Ab0tHYcZEiOzvFIfJrkA-pccFhU=s64",
       "userId": "17109198128714142667"
      },
-     "user_tz": -60
+     "user_tz": -60.0
     },
     "id": "NHr4OvvXC8ax",
     "outputId": "a4b80acf-92f2-4d63-af62-d3348798cdd0"
@@ -384,7 +384,7 @@
       ]
      },
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     },
     {
      "name": "stdout",
@@ -417,7 +417,7 @@
       ]
      },
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     },
     {
      "name": "stdout",
@@ -463,19 +463,19 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 54
+     "height": 54.0
     },
     "colab_type": "code",
     "executionInfo": {
-     "elapsed": 1589,
+     "elapsed": 1589.0,
      "status": "ok",
-     "timestamp": 1586778213672,
+     "timestamp": 1.586778213672E12,
      "user": {
       "displayName": "Leticia Fernandes",
       "photoUrl": "https://lh3.googleusercontent.com/a-/AOh14Gj3U_hSW1M2-Ab0tHYcZEiOzvFIfJrkA-pccFhU=s64",
       "userId": "17109198128714142667"
      },
-     "user_tz": -60
+     "user_tz": -60.0
     },
     "id": "sPGaYs0Qx0z3",
     "outputId": "5b1ec961-2752-4795-934a-50647b0f8d51"
@@ -597,19 +597,19 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 796
+     "height": 796.0
     },
     "colab_type": "code",
     "executionInfo": {
-     "elapsed": 14133,
+     "elapsed": 14133.0,
      "status": "ok",
-     "timestamp": 1586778235659,
+     "timestamp": 1.586778235659E12,
      "user": {
       "displayName": "Leticia Fernandes",
       "photoUrl": "https://lh3.googleusercontent.com/a-/AOh14Gj3U_hSW1M2-Ab0tHYcZEiOzvFIfJrkA-pccFhU=s64",
       "userId": "17109198128714142667"
      },
-     "user_tz": -60
+     "user_tz": -60.0
     },
     "id": "dxQJwbedb2wQ",
     "outputId": "87c0e05a-13bb-4b83-a2db-043587a9f38f"

--- a/notebooks/TSFEL_predicting_NormalVsPathologicalknee.ipynb
+++ b/notebooks/TSFEL_predicting_NormalVsPathologicalknee.ipynb
@@ -24,19 +24,19 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 1000.0
+     "height": 1000
     },
     "colab_type": "code",
     "executionInfo": {
-     "elapsed": 25663.0,
+     "elapsed": 25663,
      "status": "ok",
-     "timestamp": 1.586777469202E12,
+     "timestamp": 1586777469202,
      "user": {
       "displayName": "Leticia Fernandes",
       "photoUrl": "https://lh3.googleusercontent.com/a-/AOh14Gj3U_hSW1M2-Ab0tHYcZEiOzvFIfJrkA-pccFhU=s64",
       "userId": "17109198128714142667"
      },
-     "user_tz": -60.0
+     "user_tz": -60
     },
     "id": "yQblfSnCkD19",
     "outputId": "53de2f4b-e4c9-465f-c6e9-26f978962fa2"
@@ -271,19 +271,19 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 599.0
+     "height": 599
     },
     "colab_type": "code",
     "executionInfo": {
-     "elapsed": 2152.0,
+     "elapsed": 2152,
      "status": "ok",
-     "timestamp": 1.586777487184E12,
+     "timestamp": 1586777487184,
      "user": {
       "displayName": "Leticia Fernandes",
       "photoUrl": "https://lh3.googleusercontent.com/a-/AOh14Gj3U_hSW1M2-Ab0tHYcZEiOzvFIfJrkA-pccFhU=s64",
       "userId": "17109198128714142667"
      },
-     "user_tz": -60.0
+     "user_tz": -60
     },
     "id": "Byr434P7lvkm",
     "outputId": "feed2286-9334-4a52-e3a0-1564f3ce8450"
@@ -341,19 +341,19 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 221.0
+     "height": 221
     },
     "colab_type": "code",
     "executionInfo": {
-     "elapsed": 40167.0,
+     "elapsed": 40167,
      "status": "ok",
-     "timestamp": 1.586777529356E12,
+     "timestamp": 1586777529356,
      "user": {
       "displayName": "Leticia Fernandes",
       "photoUrl": "https://lh3.googleusercontent.com/a-/AOh14Gj3U_hSW1M2-Ab0tHYcZEiOzvFIfJrkA-pccFhU=s64",
       "userId": "17109198128714142667"
      },
-     "user_tz": -60.0
+     "user_tz": -60
     },
     "id": "Z5-x4VIEmj_O",
     "outputId": "84b95291-3077-4380-85e5-c1bf83a61b4d"
@@ -388,7 +388,7 @@
       ]
      },
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
@@ -421,7 +421,7 @@
       ]
      },
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     },
     {
      "name": "stdout",
@@ -462,19 +462,19 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 54.0
+     "height": 54
     },
     "colab_type": "code",
     "executionInfo": {
-     "elapsed": 1809.0,
+     "elapsed": 1809,
      "status": "ok",
-     "timestamp": 1.586777534384E12,
+     "timestamp": 1586777534384,
      "user": {
       "displayName": "Leticia Fernandes",
       "photoUrl": "https://lh3.googleusercontent.com/a-/AOh14Gj3U_hSW1M2-Ab0tHYcZEiOzvFIfJrkA-pccFhU=s64",
       "userId": "17109198128714142667"
      },
-     "user_tz": -60.0
+     "user_tz": -60
     },
     "id": "232qYekFohEn",
     "outputId": "629aeb1b-33a8-4628-cb22-905735062303"
@@ -541,19 +541,19 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 185.0
+     "height": 185
     },
     "colab_type": "code",
     "executionInfo": {
-     "elapsed": 833.0,
+     "elapsed": 833,
      "status": "ok",
-     "timestamp": 1.586777540937E12,
+     "timestamp": 1586777540937,
      "user": {
       "displayName": "Leticia Fernandes",
       "photoUrl": "https://lh3.googleusercontent.com/a-/AOh14Gj3U_hSW1M2-Ab0tHYcZEiOzvFIfJrkA-pccFhU=s64",
       "userId": "17109198128714142667"
      },
-     "user_tz": -60.0
+     "user_tz": -60
     },
     "id": "82aqGd22mrZ_",
     "outputId": "2eb49883-706e-47f8-e67b-a1d7644fef54"
@@ -599,19 +599,19 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 338.0
+     "height": 338
     },
     "colab_type": "code",
     "executionInfo": {
-     "elapsed": 1111.0,
+     "elapsed": 1111,
      "status": "ok",
-     "timestamp": 1.586777544492E12,
+     "timestamp": 1586777544492,
      "user": {
       "displayName": "Leticia Fernandes",
       "photoUrl": "https://lh3.googleusercontent.com/a-/AOh14Gj3U_hSW1M2-Ab0tHYcZEiOzvFIfJrkA-pccFhU=s64",
       "userId": "17109198128714142667"
      },
-     "user_tz": -60.0
+     "user_tz": -60
     },
     "id": "LqQAkWDsm8hw",
     "outputId": "9d2b8e80-d5b5-49ca-8668-a2b511b649e8"

--- a/notebooks/TSFEL_predicting_NormalVsPathologicalknee.ipynb
+++ b/notebooks/TSFEL_predicting_NormalVsPathologicalknee.ipynb
@@ -24,19 +24,19 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 1000
+     "height": 1000.0
     },
     "colab_type": "code",
     "executionInfo": {
-     "elapsed": 25663,
+     "elapsed": 25663.0,
      "status": "ok",
-     "timestamp": 1586777469202,
+     "timestamp": 1.586777469202E12,
      "user": {
       "displayName": "Leticia Fernandes",
       "photoUrl": "https://lh3.googleusercontent.com/a-/AOh14Gj3U_hSW1M2-Ab0tHYcZEiOzvFIfJrkA-pccFhU=s64",
       "userId": "17109198128714142667"
      },
-     "user_tz": -60
+     "user_tz": -60.0
     },
     "id": "yQblfSnCkD19",
     "outputId": "53de2f4b-e4c9-465f-c6e9-26f978962fa2"
@@ -250,10 +250,10 @@
     "\n",
     "# Dividing into train and test sets. Splitting signal in windows\n",
     "# Using 2 normal files and 2 pathological files for test set\n",
-    "x_train = list(itertools.chain(*[tsfel.signal_window_spliter(signal[i], window_size, overlap=0) for signal in\n",
+    "x_train = list(itertools.chain(*[tsfel.signal_window_splitter(signal[i], window_size, overlap=0) for signal in\n",
     "                                 [normalfl, patholofl] for i in range(len(normalfl) - 2)]))\n",
     "\n",
-    "x_test = list(itertools.chain(*[tsfel.signal_window_spliter(signal[i], window_size, overlap=0) for signal in\n",
+    "x_test = list(itertools.chain(*[tsfel.signal_window_splitter(signal[i], window_size, overlap=0) for signal in\n",
     "                                [normalfl, patholofl] for i in [len(normalfl) - 2, len(normalfl) - 1]]))\n",
     "\n",
     "y_train = np.concatenate(\n",
@@ -271,19 +271,19 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 599
+     "height": 599.0
     },
     "colab_type": "code",
     "executionInfo": {
-     "elapsed": 2152,
+     "elapsed": 2152.0,
      "status": "ok",
-     "timestamp": 1586777487184,
+     "timestamp": 1.586777487184E12,
      "user": {
       "displayName": "Leticia Fernandes",
       "photoUrl": "https://lh3.googleusercontent.com/a-/AOh14Gj3U_hSW1M2-Ab0tHYcZEiOzvFIfJrkA-pccFhU=s64",
       "userId": "17109198128714142667"
      },
-     "user_tz": -60
+     "user_tz": -60.0
     },
     "id": "Byr434P7lvkm",
     "outputId": "feed2286-9334-4a52-e3a0-1564f3ce8450"
@@ -341,19 +341,19 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 221
+     "height": 221.0
     },
     "colab_type": "code",
     "executionInfo": {
-     "elapsed": 40167,
+     "elapsed": 40167.0,
      "status": "ok",
-     "timestamp": 1586777529356,
+     "timestamp": 1.586777529356E12,
      "user": {
       "displayName": "Leticia Fernandes",
       "photoUrl": "https://lh3.googleusercontent.com/a-/AOh14Gj3U_hSW1M2-Ab0tHYcZEiOzvFIfJrkA-pccFhU=s64",
       "userId": "17109198128714142667"
      },
-     "user_tz": -60
+     "user_tz": -60.0
     },
     "id": "Z5-x4VIEmj_O",
     "outputId": "84b95291-3077-4380-85e5-c1bf83a61b4d"
@@ -388,7 +388,7 @@
       ]
      },
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     },
     {
      "name": "stdout",
@@ -421,7 +421,7 @@
       ]
      },
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     },
     {
      "name": "stdout",
@@ -462,19 +462,19 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 54
+     "height": 54.0
     },
     "colab_type": "code",
     "executionInfo": {
-     "elapsed": 1809,
+     "elapsed": 1809.0,
      "status": "ok",
-     "timestamp": 1586777534384,
+     "timestamp": 1.586777534384E12,
      "user": {
       "displayName": "Leticia Fernandes",
       "photoUrl": "https://lh3.googleusercontent.com/a-/AOh14Gj3U_hSW1M2-Ab0tHYcZEiOzvFIfJrkA-pccFhU=s64",
       "userId": "17109198128714142667"
      },
-     "user_tz": -60
+     "user_tz": -60.0
     },
     "id": "232qYekFohEn",
     "outputId": "629aeb1b-33a8-4628-cb22-905735062303"
@@ -541,19 +541,19 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 185
+     "height": 185.0
     },
     "colab_type": "code",
     "executionInfo": {
-     "elapsed": 833,
+     "elapsed": 833.0,
      "status": "ok",
-     "timestamp": 1586777540937,
+     "timestamp": 1.586777540937E12,
      "user": {
       "displayName": "Leticia Fernandes",
       "photoUrl": "https://lh3.googleusercontent.com/a-/AOh14Gj3U_hSW1M2-Ab0tHYcZEiOzvFIfJrkA-pccFhU=s64",
       "userId": "17109198128714142667"
      },
-     "user_tz": -60
+     "user_tz": -60.0
     },
     "id": "82aqGd22mrZ_",
     "outputId": "2eb49883-706e-47f8-e67b-a1d7644fef54"
@@ -599,19 +599,19 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 338
+     "height": 338.0
     },
     "colab_type": "code",
     "executionInfo": {
-     "elapsed": 1111,
+     "elapsed": 1111.0,
      "status": "ok",
-     "timestamp": 1586777544492,
+     "timestamp": 1.586777544492E12,
      "user": {
       "displayName": "Leticia Fernandes",
       "photoUrl": "https://lh3.googleusercontent.com/a-/AOh14Gj3U_hSW1M2-Ab0tHYcZEiOzvFIfJrkA-pccFhU=s64",
       "userId": "17109198128714142667"
      },
-     "user_tz": -60
+     "user_tz": -60.0
     },
     "id": "LqQAkWDsm8hw",
     "outputId": "9d2b8e80-d5b5-49ca-8668-a2b511b649e8"

--- a/tsfel/feature_extraction/calc_features.py
+++ b/tsfel/feature_extraction/calc_features.py
@@ -16,7 +16,7 @@ from IPython import get_ipython
 from IPython.display import display
 
 from tsfel.utils.progress_bar import display_progress_bar, progress_bar_notebook
-from tsfel.utils.signal_processing import merge_time_series, signal_window_spliter
+from tsfel.utils.signal_processing import merge_time_series, signal_window_splitter
 
 
 def dataset_features_extractor(main_directory, feat_dict, verbose=1, **kwargs):
@@ -128,7 +128,7 @@ def dataset_features_extractor(main_directory, feat_dict, verbose=1, **kwargs):
 
         data_new = merge_time_series(pp_sensor_data, resample_rate, time_unit)
 
-        windows = signal_window_spliter(data_new, window_size, overlap)
+        windows = signal_window_splitter(data_new, window_size, overlap)
 
         if features_path:
             features = time_series_features_extractor(feat_dict, windows, fs=resample_rate, verbose=0,
@@ -176,7 +176,7 @@ def calc_features(wind_sig, dict_features, fs, **kwargs):
     return feat_val
 
 
-def time_series_features_extractor(dict_features, signal_windows, fs=None, window_spliter=False, verbose=1, **kwargs):
+def time_series_features_extractor(dict_features, signal_windows, fs=None, verbose=1, **kwargs):
     """Extraction of time series features.
 
     Parameters
@@ -187,8 +187,6 @@ def time_series_features_extractor(dict_features, signal_windows, fs=None, windo
         Input from which features are computed, window
     fs : int or None
         Sampling frequency
-    window_spliter: bool
-        If True computes the signal windows
     verbose : int
         Level of function communication
         (0 or 1 (Default))
@@ -216,7 +214,7 @@ def time_series_features_extractor(dict_features, signal_windows, fs=None, windo
     if verbose == 1:
         print("*** Feature extraction started ***")
 
-    window_size = kwargs.get('window_size', 100)
+    window_size = kwargs.get('window_size', None)
     overlap = kwargs.get('overlap', 0)
     features_path = kwargs.get('features_path', None)
     names = kwargs.get('header_names', None)
@@ -240,8 +238,8 @@ def time_series_features_extractor(dict_features, signal_windows, fs=None, windo
     if names is not None:
         names = list(names)
 
-    if window_spliter:
-        signal_windows = signal_window_spliter(signal_windows, window_size, overlap)
+    if window_size is not None:
+        signal_windows = signal_window_splitter(signal_windows, window_size, overlap)
 
     features_final = pd.DataFrame()
 

--- a/tsfel/utils/signal_processing.py
+++ b/tsfel/utils/signal_processing.py
@@ -3,7 +3,7 @@ import pandas as pd
 from scipy.interpolate import interp1d
 
 
-def signal_window_spliter(signal, window_size, overlap):
+def signal_window_splitter(signal, window_size, overlap):
     """Splits the signal into windows
 
     Parameters


### PR DESCRIPTION
Removing window_spliter parameter:
- Now the user only needs to define the window_size on time_series_feature_extractor method for splitting the signal into windows.
- window_size is kwarg is set to None, if is not None then the signal is split into windows.

signal_window_spliter was also rewritten as signal_window_splitter, notebooks were updated according to this nomenclature review.