### PR TITLE
lpcc error correction; warning in entropy features solved

### DIFF
--- a/tsfel/feature_extraction/features.py
+++ b/tsfel/feature_extraction/features.py
@@ -406,7 +406,10 @@ def entropy(signal, prob='standard'):
     # Handling zero probability values
     p = p[np.where(p != 0)]
 
-    if np.sum(p * np.log2(p)) / np.log2(len(signal)) == 0:
+    # If probability all in one value, there is no entropy
+    if np.log2(len(signal)) == 1:
+        return 0.0
+    elif np.sum(p * np.log2(p)) / np.log2(len(signal)) == 0:
         return 0.0
     else:
         return - np.sum(p * np.log2(p)) / np.log2(len(signal))
@@ -1505,7 +1508,7 @@ def lpcc(signal, n_coeff=12):
     lpc_coeffs = lpc(signal, n_coeff)
 
     if np.sum(lpc_coeffs) == 0:
-        return tuple(np.zeros(n_coeff))
+        return tuple(np.zeros(len(lpc_coeffs)))
 
     # Power spectrum
     powerspectrum = np.abs(np.fft.fft(lpc_coeffs)) ** 2
@@ -1546,6 +1549,10 @@ def spectral_entropy(signal, fs):
     prob = np.divide(power, power.sum())
 
     prob = prob[prob != 0]
+
+    # If probability all in one value, there is no entropy
+    if prob.size == 1:
+        return 0.0
 
     return -np.multiply(prob, np.log2(prob)).sum() / np.log2(prob.size)
 

--- a/tsfel/feature_extraction/features_utils.py
+++ b/tsfel/feature_extraction/features_utils.py
@@ -208,6 +208,11 @@ def lpc(signal, n_coeff=12):
 
     # Calculate LPC with Yule-Walker
     acf = autocorr_norm(signal)
+
+    # Assuring that works for all type of input lengths
+    if len(acf) < n_coeff:
+        n_coeff = len(acf)-1
+
     r = -acf[1:n_coeff + 1].T
     smatrix = create_symmetric_matrix(acf, n_coeff)
     if np.sum(smatrix) == 0:


### PR DESCRIPTION
**LPCC error correction:**
An error rises if the signal length was lower than the n_coeff needed by default, so if this happens the n_coeff is updated for signal length -1.
Fix #33 

**Entropy Warning:**
As entropy features are normalized, if the probability value is maximum for one evidence a zero division happened, and this is actually a zero entropy case. This was solved by returning zero as entropy value.