### PR TITLE
Fixed inconsistent windowing

### DIFF
--- a/tsfel/utils/signal_processing.py
+++ b/tsfel/utils/signal_processing.py
@@ -23,10 +23,7 @@ def signal_window_splitter(signal, window_size, overlap=0):
     """
 
     step = int(round(window_size)) if overlap == 0 else int(round(window_size * (1 - overlap)))
-    if len(signal) % window_size == 0:
-        return [signal[i:i + window_size] for i in range(0, len(signal) - step, step)]
-    else:
-        return [signal[i:i + window_size] for i in range(0, len(signal) - window_size, step)]
+    return [signal[i:i + window_size] for i in range(0, len(signal) - window_size, step)]
 
 
 def merge_time_series(data, fs_resample, time_unit):

--- a/tsfel/utils/signal_processing.py
+++ b/tsfel/utils/signal_processing.py
@@ -24,7 +24,7 @@ def signal_window_splitter(signal, window_size, overlap=0):
 
     step = int(round(window_size)) if overlap == 0 else int(round(window_size * (1 - overlap)))
     if len(signal) % window_size == 0:
-        return [signal[i:i + window_size] for i in range(0, len(signal), step)]
+        return [signal[i:i + window_size] for i in range(0, len(signal) - step, step)]
     else:
         return [signal[i:i + window_size] for i in range(0, len(signal) - window_size, step)]
 


### PR DESCRIPTION
If the input signal is an integer multiply of window_size and the overlap parameter is something other than 0, the signal_window_splitter produces windows smaller than window_size. 

**Example:**
window_size = 120
overlap = 0.5
sig= np.arange(0, 5*window_size)

w = signal_window_splitter(sig, window_size, overlap)
[len(x) for x in w]
--> [120, 120, 120, 120, 120, 120, 120, 120, 120, 60]

**Example 2:**
window_size = 127
overlap = 0.4
sig = np.arange(0,5*window_size)

w = signal_window_splitter(sig, window_size, overlap)
[len(x) for x in w]
--> [127, 127, 127, 127, 127, 127, 127, 103, 27]