### PR TITLE
fix autocorr normalized

### DIFF
--- a/tsfel/feature_extraction/features_utils.py
+++ b/tsfel/feature_extraction/features_utils.py
@@ -146,13 +146,14 @@ def autocorr_norm(signal):
 
     """
 
+    variance = np.var(signal)
     signal = np.copy(signal - signal.mean())
     r = scipy.signal.correlate(signal, signal)[-len(signal):]
 
     if np.sum(signal) == 0:
         return np.zeros(len(signal))
 
-    acf = r / (np.var(signal) * (np.arange(len(signal), 0, -1)))
+    acf = r / variance / len(signal)
 
     return acf
 


### PR DESCRIPTION
Autocorrelation normalized was not varying from 0 to 1.
This was fixed dividing by the length of the signal.