### PR TITLE
Tagging features by type of input signal - initial commit

### DIFF
--- a/tests/test_calc_features.py
+++ b/tests/test_calc_features.py
@@ -46,6 +46,8 @@ settings4 = tsfel.get_features_by_domain('spectral')
 settings5 = tsfel.get_features_by_domain()
 settings6 = tsfel.extract_sheet('Features')
 settings7 = tsfel.extract_sheet('Features_test', path_json=personal_path_json)
+settings8 = tsfel.get_features_by_tag('inertial')
+settings10 = tsfel.get_features_by_tag()
 
 # Signal processing
 data_new = tsfel.merge_time_series(sensor_data, resample_rate, time_unit)

--- a/tests/test_features_settings.py
+++ b/tests/test_features_settings.py
@@ -1,6 +1,5 @@
 import tsfel
 
-
 FEATURES_JSON = tsfel.__path__[0] + '/feature_extraction/features.json'
 
 settings0 = tsfel.load_json(FEATURES_JSON)
@@ -14,3 +13,15 @@ settings3 = tsfel.get_features_by_domain('spectral')
 settings4 = tsfel.get_features_by_domain(None)
 
 settings5 = tsfel.extract_sheet('Features')
+
+settings6 = tsfel.get_features_by_tag('audio')
+
+settings7 = tsfel.get_features_by_tag('inertial')
+
+settings8 = tsfel.get_features_by_tag('ecg')
+
+settings9 = tsfel.get_features_by_tag('eeg')
+
+settings10 = tsfel.get_features_by_tag('emg')
+
+settings11 = tsfel.get_features_by_tag(None)

--- a/tests/tests_tools/test_features.json
+++ b/tests/tests_tools/test_features.json
@@ -1,9 +1,31 @@
 {
+    "new_domain": {
+        "new_feature_with_multiple_tag": {
+            "complexity": "log",
+            "description": "A new feature with multiple tags",
+            "function": "new_feature_with_multiple_tag",
+            "parameters": "",
+            "tag": [
+                "inertial",
+                "emg"
+            ],
+            "use": "yes"
+        },
+        "new_feature_with_tag": {
+            "complexity": "constant",
+            "description": "A new feature with a tag",
+            "function": "new_feature_with_tag",
+            "parameters": "",
+            "tag": "inertial",
+            "use": "yes"
+        }
+    },
     "spectral": {
         "FFT mean coefficient": {
             "complexity": "constant",
             "description": "Computes the mean value of each spectrogram frequency.",
             "function": "tsfel.fft_mean_coeff",
+            "n_features": "nfreq",
             "parameters": {
                 "fs": 100,
                 "nfreq": 256
@@ -14,6 +36,7 @@
             "complexity": "log",
             "description": "Computes the fundamental frequency.",
             "function": "tsfel.fundamental_frequency",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
@@ -23,24 +46,29 @@
             "complexity": "log",
             "description": "Computes the human range energy ratio given by the ratio between the energy in frequency 0.6-2.5Hz and the whole energy band.",
             "function": "tsfel.human_range_energy",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
+            "tag": "inertial",
             "use": "yes"
         },
         "LPCC": {
             "complexity": "log",
             "description": "Computes the linear prediction cepstral coefficients.",
             "function": "tsfel.lpcc",
+            "n_features": "n_coeff",
             "parameters": {
                 "n_coeff": 12
             },
+            "tag": "audio",
             "use": "yes"
         },
         "MFCC": {
             "complexity": "constant",
             "description": "Computes the MEL cepstral coefficients.",
             "function": "tsfel.mfcc",
+            "n_features": "num_ceps",
             "parameters": {
                 "cep_lifter": 22,
                 "fs": 100,
@@ -49,12 +77,17 @@
                 "num_ceps": 12,
                 "pre_emphasis": 0.97
             },
+            "tag": [
+                "audio",
+                "emg"
+            ],
             "use": "yes"
         },
         "Max power spectrum": {
             "complexity": "log",
             "description": "Computes the maximum power spectrum density.",
             "function": "tsfel.max_power_spectrum",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
@@ -64,6 +97,7 @@
             "complexity": "log",
             "description": "Computes the maximum frequency.",
             "function": "tsfel.max_frequency",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
@@ -73,6 +107,7 @@
             "complexity": "log",
             "description": "Computes the median frequency.",
             "function": "tsfel.median_frequency",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
@@ -82,6 +117,7 @@
             "complexity": "log",
             "description": "Computes power spectrum density bandwidth of the signal.",
             "function": "tsfel.power_bandwidth",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
@@ -91,15 +127,18 @@
             "complexity": "linear",
             "description": "Computes the barycenter of the spectrum.",
             "function": "tsfel.spectral_centroid",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
+            "tag": "audio",
             "use": "yes"
         },
         "Spectral decrease": {
             "complexity": "log",
             "description": "Computes the amount of decreasing of the spectra amplitude.",
             "function": "tsfel.spectral_decrease",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
@@ -109,6 +148,7 @@
             "complexity": "log",
             "description": "Computes the signal spectral distance.",
             "function": "tsfel.spectral_distance",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
@@ -118,15 +158,18 @@
             "complexity": "log",
             "description": "Computes the spectral entropy of the signal based on Fourier transform.",
             "function": "tsfel.spectral_entropy",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
+            "tag": "eeg",
             "use": "yes"
         },
         "Spectral kurtosis": {
             "complexity": "linear",
             "description": "Computes the flatness of a distribution around its mean value.",
             "function": "tsfel.spectral_kurtosis",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
@@ -136,6 +179,7 @@
             "complexity": "log",
             "description": "Computes number of positive turning points of the fft magnitude signal",
             "function": "tsfel.spectral_positive_turning",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
@@ -145,15 +189,18 @@
             "complexity": "log",
             "description": "Computes the frequency where 95% of the signal magnitude is contained below of this value.",
             "function": "tsfel.spectral_roll_off",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
+            "tag": "audio",
             "use": "yes"
         },
         "Spectral roll-on": {
             "complexity": "log",
             "description": "Computes the frequency where 5% of the signal magnitude is contained below of this value.",
             "function": "tsfel.spectral_roll_on",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
@@ -163,6 +210,7 @@
             "complexity": "linear",
             "description": "Computes the asymmetry of a distribution around its mean value.",
             "function": "tsfel.spectral_skewness",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
@@ -172,6 +220,7 @@
             "complexity": "log",
             "description": "Computes the spectral slope, obtained by linear regression of the spectral amplitude.",
             "function": "tsfel.spectral_slope",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
@@ -181,6 +230,7 @@
             "complexity": "linear",
             "description": "Computes the spread of the spectrum around its mean value.",
             "function": "tsfel.spectral_spread",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
@@ -190,6 +240,7 @@
             "complexity": "log",
             "description": "Computes the amount of variation of the spectrum along time.",
             "function": "tsfel.spectral_variation",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
@@ -199,50 +250,63 @@
             "complexity": "linear",
             "description": "Computes CWT absolute mean value of each wavelet scale.",
             "function": "tsfel.wavelet_abs_mean",
+            "n_features": "widths",
             "parameters": {
                 "function": "scipy.signal.ricker",
                 "widths": "np.arange(1,10)"
             },
+            "tag": [
+                "eeg",
+                "ecg"
+            ],
             "use": "yes"
         },
         "Wavelet energy": {
             "complexity": "linear",
             "description": "Computes CWT energy of each wavelet scale.",
             "function": "tsfel.wavelet_energy",
+            "n_features": "widths",
             "parameters": {
                 "function": "scipy.signal.ricker",
                 "widths": "np.arange(1,10)"
             },
+            "tag": "eeg",
             "use": "yes"
         },
         "Wavelet entropy": {
             "complexity": "linear",
             "description": "Computes CWT entropy of the signal.",
             "function": "tsfel.wavelet_entropy",
+            "n_features": 1,
             "parameters": {
                 "function": "scipy.signal.ricker",
                 "widths": "np.arange(1,10)"
             },
+            "tag": "eeg",
             "use": "yes"
         },
         "Wavelet standard deviation": {
             "complexity": "linear",
             "description": "Computes CWT std value of each wavelet scale.",
             "function": "tsfel.wavelet_std",
+            "n_features": "widths",
             "parameters": {
                 "function": "scipy.signal.ricker",
                 "widths": "np.arange(1,10)"
             },
+            "tag": "eeg",
             "use": "yes"
         },
         "Wavelet variance": {
             "complexity": "linear",
             "description": "Computes CWT variance value of each wavelet scale.",
             "function": "tsfel.wavelet_var",
+            "n_features": "widths",
             "parameters": {
                 "function": "scipy.signal.ricker",
                 "widths": "np.arange(1,10)"
             },
+            "tag": "eeg",
             "use": "yes"
         }
     },
@@ -251,6 +315,7 @@
             "complexity": "log",
             "description": "Computes the values of ECDF (empirical cumulative distribution function) along the time axis.",
             "function": "tsfel.ecdf",
+            "n_features": "d",
             "parameters": {
                 "d": 10
             },
@@ -260,8 +325,9 @@
             "complexity": "log",
             "description": "Determines the percentile value of the ECDF.",
             "function": "tsfel.ecdf_percentile",
+            "n_features": "percentile",
             "parameters": {
-                "percentile": null
+                "percentile": "[0.2, 0.8]"
             },
             "use": "yes"
         },
@@ -269,8 +335,9 @@
             "complexity": "log",
             "description": "Determines the cumulative sum of samples that are less than the percentile.",
             "function": "tsfel.ecdf_percentile_count",
+            "n_features": "percentile",
             "parameters": {
-                "percentile": null
+                "percentile": "[0.2, 0.8]"
             },
             "use": "yes"
         },
@@ -278,6 +345,7 @@
             "complexity": "log",
             "description": "Computes the slope of the ECDF between two percentiles.",
             "function": "tsfel.ecdf_slope",
+            "n_features": 1,
             "parameters": {
                 "p_end": 0.75,
                 "p_init": 0.5
@@ -288,6 +356,7 @@
             "complexity": "log",
             "description": "Computes histogram of the signal.",
             "function": "tsfel.hist",
+            "n_features": "nbins",
             "parameters": {
                 "nbins": 10,
                 "r": 1
@@ -298,6 +367,7 @@
             "complexity": "constant",
             "description": "Computes interquartile range of the signal.",
             "function": "tsfel.interq_range",
+            "n_features": 1,
             "parameters": "",
             "use": "yes"
         },
@@ -305,6 +375,7 @@
             "complexity": "constant",
             "description": "Computes kurtosis of the signal.",
             "function": "tsfel.kurtosis",
+            "n_features": 1,
             "parameters": "",
             "use": "yes"
         },
@@ -312,6 +383,7 @@
             "complexity": "constant",
             "description": "Computes the maximum value of the signal.",
             "function": "tsfel.calc_max",
+            "n_features": 1,
             "parameters": "",
             "use": "yes"
         },
@@ -319,13 +391,16 @@
             "complexity": "constant",
             "description": "Computes the mean value of the signal.",
             "function": "tsfel.calc_mean",
+            "n_features": 1,
             "parameters": "",
+            "tag": "inertial",
             "use": "yes"
         },
         "Mean absolute deviation": {
             "complexity": "log",
             "description": "Computes mean absolute deviation of the signal.",
             "function": "tsfel.mean_abs_deviation",
+            "n_features": 1,
             "parameters": "",
             "use": "yes"
         },
@@ -333,6 +408,7 @@
             "complexity": "constant",
             "description": "Computes median of the signal.",
             "function": "tsfel.calc_median",
+            "n_features": 1,
             "parameters": "",
             "use": "yes"
         },
@@ -340,6 +416,7 @@
             "complexity": "constant",
             "description": "Computes median absolute deviation of the signal.",
             "function": "tsfel.median_abs_deviation",
+            "n_features": 1,
             "parameters": "",
             "use": "yes"
         },
@@ -347,36 +424,27 @@
             "complexity": "constant",
             "description": "Computes the minimum value of the signal.",
             "function": "tsfel.calc_min",
+            "n_features": 1,
             "parameters": "",
-            "use": "yes"
-        },
-        "New Feature": {
-            "complexity": "constant",
-            "description": "Computes a new feature.",
-            "function": "new_feature",
-            "parameters": "",
-            "use": "yes"
-        },
-        "New Feature with parameter": {
-            "complexity": "constant",
-            "description": "Computes a new feature with parameter.",
-            "function": "new_feature_with_parameter",
-            "parameters": {
-                "weight": 0.5
-            },
             "use": "yes"
         },
         "Root mean square": {
             "complexity": "constant",
             "description": "Computes root mean square of the signal.",
             "function": "tsfel.rms",
+            "n_features": 1,
             "parameters": "",
+            "tag": [
+                "emg",
+                "inertial"
+            ],
             "use": "yes"
         },
         "Skewness": {
             "complexity": "constant",
             "description": "Computes skewness of the signal.",
             "function": "tsfel.skewness",
+            "n_features": 1,
             "parameters": "",
             "use": "yes"
         },
@@ -384,6 +452,7 @@
             "complexity": "constant",
             "description": "Computes standard deviation of the signal.",
             "function": "tsfel.calc_std",
+            "n_features": 1,
             "parameters": "",
             "use": "yes"
         },
@@ -391,6 +460,7 @@
             "complexity": "constant",
             "description": "Computes variance of the signal.",
             "function": "tsfel.calc_var",
+            "n_features": 1,
             "parameters": "",
             "use": "yes"
         },
@@ -416,13 +486,16 @@
             "complexity": "log",
             "description": "Computes the absolute energy of the signal.",
             "function": "tsfel.abs_energy",
+            "n_features": 1,
             "parameters": "",
+            "tag": "audio",
             "use": "yes"
         },
         "Area under the curve": {
             "complexity": "log",
             "description": "Computes the area under the curve of the signal computed with trapezoid rule.",
             "function": "tsfel.auc",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
@@ -432,13 +505,16 @@
             "complexity": "constant",
             "description": "Computes autocorrelation of the signal.",
             "function": "tsfel.autocorr",
+            "n_features": 1,
             "parameters": "",
+            "tag": "inertial",
             "use": "yes"
         },
         "Centroid": {
             "complexity": "constant",
             "description": "Computes the centroid along the time axis.",
             "function": "tsfel.calc_centroid",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
@@ -448,15 +524,18 @@
             "complexity": "log",
             "description": "Computes the entropy of the signal using the Shannon Entropy.",
             "function": "tsfel.entropy",
+            "n_features": 1,
             "parameters": {
                 "prob": "standard"
             },
+            "tag": "eeg",
             "use": "yes"
         },
         "Mean absolute diff": {
             "complexity": "constant",
             "description": "Computes mean absolute differences of the signal.",
             "function": "tsfel.mean_abs_diff",
+            "n_features": 1,
             "parameters": "",
             "use": "yes"
         },
@@ -464,6 +543,7 @@
             "complexity": "constant",
             "description": "Computes mean of differences of the signal.",
             "function": "tsfel.mean_diff",
+            "n_features": 1,
             "parameters": "",
             "use": "yes"
         },
@@ -471,6 +551,7 @@
             "complexity": "constant",
             "description": "Computes median absolute differences of the signal.",
             "function": "tsfel.median_abs_diff",
+            "n_features": 1,
             "parameters": "",
             "use": "yes"
         },
@@ -478,6 +559,7 @@
             "complexity": "constant",
             "description": "Computes median of differences of the signal.",
             "function": "tsfel.median_diff",
+            "n_features": 1,
             "parameters": "",
             "use": "yes"
         },
@@ -485,13 +567,26 @@
             "complexity": "constant",
             "description": "Computes number of negative turning points of the signal.",
             "function": "tsfel.negative_turning",
+            "n_features": 1,
             "parameters": "",
+            "tag": "emg",
+            "use": "yes"
+        },
+        "Neighbourhood peaks": {
+            "complexity": "constant",
+            "description": "Computes the number of peaks from a defined neighbourhood of the signal.",
+            "function": "tsfel.neighbourhood_peaks",
+            "n_features": 1,
+            "parameters": {
+                "n": 10
+            },
             "use": "yes"
         },
         "Peak to peak distance": {
             "complexity": "constant",
             "description": "Computes the peak to peak distance.",
             "function": "tsfel.pk_pk_distance",
+            "n_features": 1,
             "parameters": "",
             "use": "yes"
         },
@@ -499,13 +594,16 @@
             "complexity": "constant",
             "description": "Computes number of positive turning points of the signal.",
             "function": "tsfel.positive_turning",
+            "n_features": 1,
             "parameters": "",
+            "tag": "emg",
             "use": "yes"
         },
         "Signal distance": {
             "complexity": "constant",
             "description": "Computes signal traveled distance.",
             "function": "tsfel.distance",
+            "n_features": 1,
             "parameters": "",
             "use": "yes"
         },
@@ -513,6 +611,7 @@
             "complexity": "log",
             "description": "Computes the slope of the signal by fitting a linear equation to the observed data.",
             "function": "tsfel.slope",
+            "n_features": 1,
             "parameters": "",
             "use": "yes"
         },
@@ -520,6 +619,7 @@
             "complexity": "constant",
             "description": "Computes sum of absolute differences of the signal.",
             "function": "tsfel.sum_abs_diff",
+            "n_features": 1,
             "parameters": "",
             "use": "yes"
         },
@@ -527,16 +627,23 @@
             "complexity": "constant",
             "description": "Computes the total energy of the signal.",
             "function": "tsfel.total_energy",
+            "n_features": 1,
             "parameters": {
                 "fs": 100
             },
+            "tag": "audio",
             "use": "yes"
         },
         "Zero crossing rate": {
             "complexity": "constant",
             "description": "Computes Zero-crossing rate of the signal.",
             "function": "tsfel.zero_cross",
+            "n_features": 1,
             "parameters": "",
+            "tag": [
+                "audio",
+                "emg"
+            ],
             "use": "yes"
         }
     }

--- a/tests/tests_tools/test_personal_features.py
+++ b/tests/tests_tools/test_personal_features.py
@@ -33,3 +33,40 @@ def new_feature_with_parameter(signal, weight=0.5):
         new feature with parameter
     """
     return np.mean(signal)-np.std(signal)*weight
+
+
+@set_domain("domain", "new_domain")
+@set_domain("tag", "inertial")
+def new_feature_with_tag(signal):
+    """A new feature with a tag
+    Parameters
+    ----------
+    signal : nd-array
+        Input from which new feature is computed
+    weight : float
+        float percentage
+    Returns
+    -------
+    float
+        new feature with parameter
+    """
+    return np.mean(signal)-np.std(signal)
+
+
+@set_domain("domain", "new_domain")
+@set_domain("tag", ["inertial", "emg"])
+def new_feature_with_multiple_tag(signal):
+    """A new feature with multiple tags
+    Parameters
+    ----------
+    signal : nd-array
+        Input from which new feature is computed
+    weight : float
+        float percentage
+    Returns
+    -------
+    float
+        new feature with parameter
+    """
+    return np.mean(signal)-np.std(signal)
+

--- a/tsfel/feature_extraction/features.json
+++ b/tsfel/feature_extraction/features.json
@@ -9,8 +9,7 @@
         "nfreq": 256
       },
       "n_features": "nfreq",
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Fundamental frequency": {
       "complexity": "log",
@@ -20,8 +19,7 @@
         "fs": 100
       },
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Human range energy": {
       "complexity": "log",
@@ -32,7 +30,7 @@
       },
       "n_features": 1,
       "use": "yes",
-      "tag": ""
+      "tag": "inertial"
     },
     "LPCC": {
       "complexity": "log",
@@ -59,7 +57,10 @@
       },
       "n_features": "num_ceps",
       "use": "yes",
-      "tag": ["audio", "emg"]
+      "tag": [
+        "audio",
+        "emg"
+      ]
     },
     "Max power spectrum": {
       "complexity": "log",
@@ -69,8 +70,7 @@
         "fs": 100
       },
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Maximum frequency": {
       "complexity": "log",
@@ -80,8 +80,7 @@
         "fs": 100
       },
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Median frequency": {
       "complexity": "log",
@@ -91,8 +90,7 @@
         "fs": 100
       },
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Power bandwidth": {
       "complexity": "log",
@@ -102,8 +100,7 @@
         "fs": 100
       },
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Spectral centroid": {
       "complexity": "linear",
@@ -124,8 +121,7 @@
         "fs": 100
       },
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Spectral distance": {
       "complexity": "log",
@@ -135,8 +131,7 @@
         "fs": 100
       },
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Spectral entropy": {
       "complexity": "log",
@@ -157,8 +152,7 @@
         "fs": 100
       },
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Spectral positive turning points": {
       "complexity": "log",
@@ -168,8 +162,7 @@
         "fs": 100
       },
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Spectral roll-off": {
       "complexity": "log",
@@ -190,8 +183,7 @@
         "fs": 100
       },
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Spectral skewness": {
       "complexity": "linear",
@@ -201,8 +193,7 @@
         "fs": 100
       },
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Spectral slope": {
       "complexity": "log",
@@ -212,8 +203,7 @@
         "fs": 100
       },
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Spectral spread": {
       "complexity": "linear",
@@ -223,8 +213,7 @@
         "fs": 100
       },
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Spectral variation": {
       "complexity": "log",
@@ -234,8 +223,7 @@
         "fs": 100
       },
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Wavelet absolute mean": {
       "complexity": "linear",
@@ -247,7 +235,10 @@
       },
       "n_features": "widths",
       "use": "yes",
-      "tag": ["eeg", "ecg"]
+      "tag": [
+        "eeg",
+        "ecg"
+      ]
     },
     "Wavelet energy": {
       "complexity": "linear",
@@ -307,8 +298,7 @@
         "d": 10
       },
       "n_features": "d",
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "ECDF Percentile": {
       "complexity": "log",
@@ -318,8 +308,7 @@
         "percentile": "[0.2, 0.8]"
       },
       "n_features": "percentile",
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "ECDF Percentile Count": {
       "complexity": "log",
@@ -329,8 +318,7 @@
         "percentile": "[0.2, 0.8]"
       },
       "n_features": "percentile",
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "ECDF Slope": {
       "complexity": "log",
@@ -341,8 +329,7 @@
         "p_init": 0.5
       },
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Histogram": {
       "complexity": "log",
@@ -353,8 +340,7 @@
         "r": 1
       },
       "n_features": "nbins",
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Interquartile range": {
       "complexity": "constant",
@@ -362,8 +348,7 @@
       "function": "tsfel.interq_range",
       "parameters": "",
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Kurtosis": {
       "complexity": "constant",
@@ -371,8 +356,7 @@
       "function": "tsfel.kurtosis",
       "parameters": "",
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Max": {
       "complexity": "constant",
@@ -380,8 +364,7 @@
       "function": "tsfel.calc_max",
       "parameters": "",
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Mean": {
       "complexity": "constant",
@@ -398,8 +381,7 @@
       "function": "tsfel.mean_abs_deviation",
       "parameters": "",
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Median": {
       "complexity": "constant",
@@ -407,8 +389,7 @@
       "function": "tsfel.calc_median",
       "parameters": "",
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Median absolute deviation": {
       "complexity": "constant",
@@ -416,8 +397,7 @@
       "function": "tsfel.median_abs_deviation",
       "parameters": "",
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Min": {
       "complexity": "constant",
@@ -425,8 +405,7 @@
       "function": "tsfel.calc_min",
       "parameters": "",
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Root mean square": {
       "complexity": "constant",
@@ -435,7 +414,10 @@
       "parameters": "",
       "n_features": 1,
       "use": "yes",
-      "tag": ["emg", "inertial"]
+      "tag": [
+        "emg",
+        "inertial"
+      ]
     },
     "Skewness": {
       "complexity": "constant",
@@ -443,8 +425,7 @@
       "function": "tsfel.skewness",
       "parameters": "",
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Standard deviation": {
       "complexity": "constant",
@@ -452,8 +433,7 @@
       "function": "tsfel.calc_std",
       "parameters": "",
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Variance": {
       "complexity": "constant",
@@ -461,8 +441,7 @@
       "function": "tsfel.calc_var",
       "parameters": "",
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     }
   },
   "temporal": {
@@ -483,8 +462,7 @@
         "fs": 100
       },
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Autocorrelation": {
       "complexity": "constant",
@@ -503,8 +481,7 @@
         "fs": 100
       },
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Entropy": {
       "complexity": "log",
@@ -523,8 +500,7 @@
       "function": "tsfel.mean_abs_diff",
       "parameters": "",
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Mean diff": {
       "complexity": "constant",
@@ -532,8 +508,7 @@
       "function": "tsfel.mean_diff",
       "parameters": "",
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Median absolute diff": {
       "complexity": "constant",
@@ -541,8 +516,7 @@
       "function": "tsfel.median_abs_diff",
       "parameters": "",
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Median diff": {
       "complexity": "constant",
@@ -550,8 +524,7 @@
       "function": "tsfel.median_diff",
       "parameters": "",
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Negative turning points": {
       "complexity": "constant",
@@ -570,8 +543,7 @@
         "n": 10
       },
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Peak to peak distance": {
       "complexity": "constant",
@@ -579,8 +551,7 @@
       "function": "tsfel.pk_pk_distance",
       "parameters": "",
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Positive turning points": {
       "complexity": "constant",
@@ -597,8 +568,7 @@
       "function": "tsfel.distance",
       "parameters": "",
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Slope": {
       "complexity": "log",
@@ -606,8 +576,7 @@
       "function": "tsfel.slope",
       "parameters": "",
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Sum absolute diff": {
       "complexity": "constant",
@@ -615,8 +584,7 @@
       "function": "tsfel.sum_abs_diff",
       "parameters": "",
       "n_features": 1,
-      "use": "yes",
-      "tag": ""
+      "use": "yes"
     },
     "Total energy": {
       "complexity": "constant",
@@ -636,7 +604,10 @@
       "parameters": "",
       "n_features": 1,
       "use": "yes",
-      "tag": ["audio", "emg"]
+      "tag": [
+        "audio",
+        "emg"
+      ]
     }
   }
 }

--- a/tsfel/feature_extraction/features.json
+++ b/tsfel/feature_extraction/features.json
@@ -1,581 +1,642 @@
 {
-    "spectral": {
-        "FFT mean coefficient": {
-            "complexity": "constant",
-            "description": "Computes the mean value of each spectrogram frequency.",
-            "function": "tsfel.fft_mean_coeff",
-            "parameters": {
-                "fs": 100,
-                "nfreq": 256
-            },
-            "n_features": "nfreq",
-            "use": "yes"
-        },
-        "Fundamental frequency": {
-            "complexity": "log",
-            "description": "Computes the fundamental frequency.",
-            "function": "tsfel.fundamental_frequency",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Human range energy": {
-            "complexity": "log",
-            "description": "Computes the human range energy ratio given by the ratio between the energy in frequency 0.6-2.5Hz and the whole energy band.",
-            "function": "tsfel.human_range_energy",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "LPCC": {
-            "complexity": "log",
-            "description": "Computes the linear prediction cepstral coefficients.",
-            "function": "tsfel.lpcc",
-            "parameters": {
-                "n_coeff": 12
-            },
-            "n_features": "n_coeff",
-            "use": "yes"
-        },
-        "MFCC": {
-            "complexity": "constant",
-            "description": "Computes the MEL cepstral coefficients.",
-            "function": "tsfel.mfcc",
-            "parameters": {
-                "cep_lifter": 22,
-                "fs": 100,
-                "nfft": 512,
-                "nfilt": 40,
-                "num_ceps": 12,
-                "pre_emphasis": 0.97
-            },
-            "n_features": "num_ceps",
-            "use": "yes"
-        },
-        "Max power spectrum": {
-            "complexity": "log",
-            "description": "Computes the maximum power spectrum density.",
-            "function": "tsfel.max_power_spectrum",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Maximum frequency": {
-            "complexity": "log",
-            "description": "Computes the maximum frequency.",
-            "function": "tsfel.max_frequency",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Median frequency": {
-            "complexity": "log",
-            "description": "Computes the median frequency.",
-            "function": "tsfel.median_frequency",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Power bandwidth": {
-            "complexity": "log",
-            "description": "Computes power spectrum density bandwidth of the signal.",
-            "function": "tsfel.power_bandwidth",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Spectral centroid": {
-            "complexity": "linear",
-            "description": "Computes the barycenter of the spectrum.",
-            "function": "tsfel.spectral_centroid",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Spectral decrease": {
-            "complexity": "log",
-            "description": "Computes the amount of decreasing of the spectra amplitude.",
-            "function": "tsfel.spectral_decrease",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Spectral distance": {
-            "complexity": "log",
-            "description": "Computes the signal spectral distance.",
-            "function": "tsfel.spectral_distance",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Spectral entropy": {
-            "complexity": "log",
-            "description": "Computes the spectral entropy of the signal based on Fourier transform.",
-            "function": "tsfel.spectral_entropy",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Spectral kurtosis": {
-            "complexity": "linear",
-            "description": "Computes the flatness of a distribution around its mean value.",
-            "function": "tsfel.spectral_kurtosis",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Spectral positive turning points": {
-            "complexity": "log",
-            "description": "Computes number of positive turning points of the fft magnitude signal",
-            "function": "tsfel.spectral_positive_turning",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Spectral roll-off": {
-            "complexity": "log",
-            "description": "Computes the frequency where 95% of the signal magnitude is contained below of this value.",
-            "function": "tsfel.spectral_roll_off",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Spectral roll-on": {
-            "complexity": "log",
-            "description": "Computes the frequency where 5% of the signal magnitude is contained below of this value.",
-            "function": "tsfel.spectral_roll_on",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Spectral skewness": {
-            "complexity": "linear",
-            "description": "Computes the asymmetry of a distribution around its mean value.",
-            "function": "tsfel.spectral_skewness",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Spectral slope": {
-            "complexity": "log",
-            "description": "Computes the spectral slope, obtained by linear regression of the spectral amplitude.",
-            "function": "tsfel.spectral_slope",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Spectral spread": {
-            "complexity": "linear",
-            "description": "Computes the spread of the spectrum around its mean value.",
-            "function": "tsfel.spectral_spread",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Spectral variation": {
-            "complexity": "log",
-            "description": "Computes the amount of variation of the spectrum along time.",
-            "function": "tsfel.spectral_variation",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Wavelet absolute mean": {
-            "complexity": "linear",
-            "description": "Computes CWT absolute mean value of each wavelet scale.",
-            "function": "tsfel.wavelet_abs_mean",
-            "parameters": {
-                "function": "scipy.signal.ricker",
-                "widths": "np.arange(1,10)"
-            },
-            "n_features": "widths",
-            "use": "yes"
-        },
-        "Wavelet energy": {
-            "complexity": "linear",
-            "description": "Computes CWT energy of each wavelet scale.",
-            "function": "tsfel.wavelet_energy",
-            "parameters": {
-                "function": "scipy.signal.ricker",
-                "widths": "np.arange(1,10)"
-            },
-            "n_features": "widths",
-            "use": "yes"
-        },
-        "Wavelet entropy": {
-            "complexity": "linear",
-            "description": "Computes CWT entropy of the signal.",
-            "function": "tsfel.wavelet_entropy",
-            "parameters": {
-                "function": "scipy.signal.ricker",
-                "widths": "np.arange(1,10)"
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Wavelet standard deviation": {
-            "complexity": "linear",
-            "description": "Computes CWT std value of each wavelet scale.",
-            "function": "tsfel.wavelet_std",
-            "parameters": {
-                "function": "scipy.signal.ricker",
-                "widths": "np.arange(1,10)"
-            },
-            "n_features": "widths",
-            "use": "yes"
-        },
-        "Wavelet variance": {
-            "complexity": "linear",
-            "description": "Computes CWT variance value of each wavelet scale.",
-            "function": "tsfel.wavelet_var",
-            "parameters": {
-                "function": "scipy.signal.ricker",
-                "widths": "np.arange(1,10)"
-            },
-            "n_features": "widths",
-            "use": "yes"
-        }
+  "spectral": {
+    "FFT mean coefficient": {
+      "complexity": "constant",
+      "description": "Computes the mean value of each spectrogram frequency.",
+      "function": "tsfel.fft_mean_coeff",
+      "parameters": {
+        "fs": 100,
+        "nfreq": 256
+      },
+      "n_features": "nfreq",
+      "use": "yes",
+      "tag": ""
     },
-    "statistical": {
-        "ECDF": {
-            "complexity": "log",
-            "description": "Computes the values of ECDF (empirical cumulative distribution function) along the time axis.",
-            "function": "tsfel.ecdf",
-            "parameters": {
-                "d": 10
-            },
-            "n_features": "d",
-            "use": "yes"
-        },
-        "ECDF Percentile": {
-            "complexity": "log",
-            "description": "Determines the percentile value of the ECDF.",
-            "function": "tsfel.ecdf_percentile",
-            "parameters": {
-                "percentile": "[0.2, 0.8]"
-            },
-            "n_features": "percentile",
-            "use": "yes"
-        },
-        "ECDF Percentile Count": {
-            "complexity": "log",
-            "description": "Determines the cumulative sum of samples that are less than the percentile.",
-            "function": "tsfel.ecdf_percentile_count",
-            "parameters": {
-                "percentile": "[0.2, 0.8]"
-            },
-            "n_features": "percentile",
-            "use": "yes"
-        },
-        "ECDF Slope": {
-            "complexity": "log",
-            "description": "Computes the slope of the ECDF between two percentiles.",
-            "function": "tsfel.ecdf_slope",
-            "parameters": {
-                "p_end": 0.75,
-                "p_init": 0.5
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Histogram": {
-            "complexity": "log",
-            "description": "Computes histogram of the signal.",
-            "function": "tsfel.hist",
-            "parameters": {
-                "nbins": 10,
-                "r": 1
-            },
-            "n_features": "nbins",
-            "use": "yes"
-        },
-        "Interquartile range": {
-            "complexity": "constant",
-            "description": "Computes interquartile range of the signal.",
-            "function": "tsfel.interq_range",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Kurtosis": {
-            "complexity": "constant",
-            "description": "Computes kurtosis of the signal.",
-            "function": "tsfel.kurtosis",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Max": {
-            "complexity": "constant",
-            "description": "Computes the maximum value of the signal.",
-            "function": "tsfel.calc_max",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Mean": {
-            "complexity": "constant",
-            "description": "Computes the mean value of the signal.",
-            "function": "tsfel.calc_mean",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Mean absolute deviation": {
-            "complexity": "log",
-            "description": "Computes mean absolute deviation of the signal.",
-            "function": "tsfel.mean_abs_deviation",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Median": {
-            "complexity": "constant",
-            "description": "Computes median of the signal.",
-            "function": "tsfel.calc_median",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Median absolute deviation": {
-            "complexity": "constant",
-            "description": "Computes median absolute deviation of the signal.",
-            "function": "tsfel.median_abs_deviation",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Min": {
-            "complexity": "constant",
-            "description": "Computes the minimum value of the signal.",
-            "function": "tsfel.calc_min",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Root mean square": {
-            "complexity": "constant",
-            "description": "Computes root mean square of the signal.",
-            "function": "tsfel.rms",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Skewness": {
-            "complexity": "constant",
-            "description": "Computes skewness of the signal.",
-            "function": "tsfel.skewness",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Standard deviation": {
-            "complexity": "constant",
-            "description": "Computes standard deviation of the signal.",
-            "function": "tsfel.calc_std",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Variance": {
-            "complexity": "constant",
-            "description": "Computes variance of the signal.",
-            "function": "tsfel.calc_var",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        }
+    "Fundamental frequency": {
+      "complexity": "log",
+      "description": "Computes the fundamental frequency.",
+      "function": "tsfel.fundamental_frequency",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
     },
-    "temporal": {
-        "Absolute energy": {
-            "complexity": "log",
-            "description": "Computes the absolute energy of the signal.",
-            "function": "tsfel.abs_energy",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Area under the curve": {
-            "complexity": "log",
-            "description": "Computes the area under the curve of the signal computed with trapezoid rule.",
-            "function": "tsfel.auc",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Autocorrelation": {
-            "complexity": "constant",
-            "description": "Computes autocorrelation of the signal.",
-            "function": "tsfel.autocorr",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Centroid": {
-            "complexity": "constant",
-            "description": "Computes the centroid along the time axis.",
-            "function": "tsfel.calc_centroid",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Entropy": {
-            "complexity": "log",
-            "description": "Computes the entropy of the signal using the Shannon Entropy.",
-            "function": "tsfel.entropy",
-            "parameters": {
-                "prob": "standard"
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Mean absolute diff": {
-            "complexity": "constant",
-            "description": "Computes mean absolute differences of the signal.",
-            "function": "tsfel.mean_abs_diff",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Mean diff": {
-            "complexity": "constant",
-            "description": "Computes mean of differences of the signal.",
-            "function": "tsfel.mean_diff",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Median absolute diff": {
-            "complexity": "constant",
-            "description": "Computes median absolute differences of the signal.",
-            "function": "tsfel.median_abs_diff",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Median diff": {
-            "complexity": "constant",
-            "description": "Computes median of differences of the signal.",
-            "function": "tsfel.median_diff",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Negative turning points": {
-            "complexity": "constant",
-            "description": "Computes number of negative turning points of the signal.",
-            "function": "tsfel.negative_turning",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Neighbourhood peaks": {
-            "complexity": "constant",
-            "description": "Computes the number of peaks from a defined neighbourhood of the signal.",
-            "function": "tsfel.neighbourhood_peaks",
-            "parameters": {
-                "n": 10
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Peak to peak distance": {
-            "complexity": "constant",
-            "description": "Computes the peak to peak distance.",
-            "function": "tsfel.pk_pk_distance",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Positive turning points": {
-            "complexity": "constant",
-            "description": "Computes number of positive turning points of the signal.",
-            "function": "tsfel.positive_turning",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Signal distance": {
-            "complexity": "constant",
-            "description": "Computes signal traveled distance.",
-            "function": "tsfel.distance",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Slope": {
-            "complexity": "log",
-            "description": "Computes the slope of the signal by fitting a linear equation to the observed data.",
-            "function": "tsfel.slope",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Sum absolute diff": {
-            "complexity": "constant",
-            "description": "Computes sum of absolute differences of the signal.",
-            "function": "tsfel.sum_abs_diff",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Total energy": {
-            "complexity": "constant",
-            "description": "Computes the total energy of the signal.",
-            "function": "tsfel.total_energy",
-            "parameters": {
-                "fs": 100
-            },
-            "n_features": 1,
-            "use": "yes"
-        },
-        "Zero crossing rate": {
-            "complexity": "constant",
-            "description": "Computes Zero-crossing rate of the signal.",
-            "function": "tsfel.zero_cross",
-            "parameters": "",
-            "n_features": 1,
-            "use": "yes"
-        }
+    "Human range energy": {
+      "complexity": "log",
+      "description": "Computes the human range energy ratio given by the ratio between the energy in frequency 0.6-2.5Hz and the whole energy band.",
+      "function": "tsfel.human_range_energy",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "LPCC": {
+      "complexity": "log",
+      "description": "Computes the linear prediction cepstral coefficients.",
+      "function": "tsfel.lpcc",
+      "parameters": {
+        "n_coeff": 12
+      },
+      "n_features": "n_coeff",
+      "use": "yes",
+      "tag": "audio"
+    },
+    "MFCC": {
+      "complexity": "constant",
+      "description": "Computes the MEL cepstral coefficients.",
+      "function": "tsfel.mfcc",
+      "parameters": {
+        "cep_lifter": 22,
+        "fs": 100,
+        "nfft": 512,
+        "nfilt": 40,
+        "num_ceps": 12,
+        "pre_emphasis": 0.97
+      },
+      "n_features": "num_ceps",
+      "use": "yes",
+      "tag": ["audio", "emg"]
+    },
+    "Max power spectrum": {
+      "complexity": "log",
+      "description": "Computes the maximum power spectrum density.",
+      "function": "tsfel.max_power_spectrum",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Maximum frequency": {
+      "complexity": "log",
+      "description": "Computes the maximum frequency.",
+      "function": "tsfel.max_frequency",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Median frequency": {
+      "complexity": "log",
+      "description": "Computes the median frequency.",
+      "function": "tsfel.median_frequency",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Power bandwidth": {
+      "complexity": "log",
+      "description": "Computes power spectrum density bandwidth of the signal.",
+      "function": "tsfel.power_bandwidth",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Spectral centroid": {
+      "complexity": "linear",
+      "description": "Computes the barycenter of the spectrum.",
+      "function": "tsfel.spectral_centroid",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": "audio"
+    },
+    "Spectral decrease": {
+      "complexity": "log",
+      "description": "Computes the amount of decreasing of the spectra amplitude.",
+      "function": "tsfel.spectral_decrease",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Spectral distance": {
+      "complexity": "log",
+      "description": "Computes the signal spectral distance.",
+      "function": "tsfel.spectral_distance",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Spectral entropy": {
+      "complexity": "log",
+      "description": "Computes the spectral entropy of the signal based on Fourier transform.",
+      "function": "tsfel.spectral_entropy",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": "eeg"
+    },
+    "Spectral kurtosis": {
+      "complexity": "linear",
+      "description": "Computes the flatness of a distribution around its mean value.",
+      "function": "tsfel.spectral_kurtosis",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Spectral positive turning points": {
+      "complexity": "log",
+      "description": "Computes number of positive turning points of the fft magnitude signal",
+      "function": "tsfel.spectral_positive_turning",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Spectral roll-off": {
+      "complexity": "log",
+      "description": "Computes the frequency where 95% of the signal magnitude is contained below of this value.",
+      "function": "tsfel.spectral_roll_off",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": "audio"
+    },
+    "Spectral roll-on": {
+      "complexity": "log",
+      "description": "Computes the frequency where 5% of the signal magnitude is contained below of this value.",
+      "function": "tsfel.spectral_roll_on",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Spectral skewness": {
+      "complexity": "linear",
+      "description": "Computes the asymmetry of a distribution around its mean value.",
+      "function": "tsfel.spectral_skewness",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Spectral slope": {
+      "complexity": "log",
+      "description": "Computes the spectral slope, obtained by linear regression of the spectral amplitude.",
+      "function": "tsfel.spectral_slope",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Spectral spread": {
+      "complexity": "linear",
+      "description": "Computes the spread of the spectrum around its mean value.",
+      "function": "tsfel.spectral_spread",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Spectral variation": {
+      "complexity": "log",
+      "description": "Computes the amount of variation of the spectrum along time.",
+      "function": "tsfel.spectral_variation",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Wavelet absolute mean": {
+      "complexity": "linear",
+      "description": "Computes CWT absolute mean value of each wavelet scale.",
+      "function": "tsfel.wavelet_abs_mean",
+      "parameters": {
+        "function": "scipy.signal.ricker",
+        "widths": "np.arange(1,10)"
+      },
+      "n_features": "widths",
+      "use": "yes",
+      "tag": ["eeg", "ecg"]
+    },
+    "Wavelet energy": {
+      "complexity": "linear",
+      "description": "Computes CWT energy of each wavelet scale.",
+      "function": "tsfel.wavelet_energy",
+      "parameters": {
+        "function": "scipy.signal.ricker",
+        "widths": "np.arange(1,10)"
+      },
+      "n_features": "widths",
+      "use": "yes",
+      "tag": "eeg"
+    },
+    "Wavelet entropy": {
+      "complexity": "linear",
+      "description": "Computes CWT entropy of the signal.",
+      "function": "tsfel.wavelet_entropy",
+      "parameters": {
+        "function": "scipy.signal.ricker",
+        "widths": "np.arange(1,10)"
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": "eeg"
+    },
+    "Wavelet standard deviation": {
+      "complexity": "linear",
+      "description": "Computes CWT std value of each wavelet scale.",
+      "function": "tsfel.wavelet_std",
+      "parameters": {
+        "function": "scipy.signal.ricker",
+        "widths": "np.arange(1,10)"
+      },
+      "n_features": "widths",
+      "use": "yes",
+      "tag": "eeg"
+    },
+    "Wavelet variance": {
+      "complexity": "linear",
+      "description": "Computes CWT variance value of each wavelet scale.",
+      "function": "tsfel.wavelet_var",
+      "parameters": {
+        "function": "scipy.signal.ricker",
+        "widths": "np.arange(1,10)"
+      },
+      "n_features": "widths",
+      "use": "yes",
+      "tag": "eeg"
     }
+  },
+  "statistical": {
+    "ECDF": {
+      "complexity": "log",
+      "description": "Computes the values of ECDF (empirical cumulative distribution function) along the time axis.",
+      "function": "tsfel.ecdf",
+      "parameters": {
+        "d": 10
+      },
+      "n_features": "d",
+      "use": "yes",
+      "tag": ""
+    },
+    "ECDF Percentile": {
+      "complexity": "log",
+      "description": "Determines the percentile value of the ECDF.",
+      "function": "tsfel.ecdf_percentile",
+      "parameters": {
+        "percentile": "[0.2, 0.8]"
+      },
+      "n_features": "percentile",
+      "use": "yes",
+      "tag": ""
+    },
+    "ECDF Percentile Count": {
+      "complexity": "log",
+      "description": "Determines the cumulative sum of samples that are less than the percentile.",
+      "function": "tsfel.ecdf_percentile_count",
+      "parameters": {
+        "percentile": "[0.2, 0.8]"
+      },
+      "n_features": "percentile",
+      "use": "yes",
+      "tag": ""
+    },
+    "ECDF Slope": {
+      "complexity": "log",
+      "description": "Computes the slope of the ECDF between two percentiles.",
+      "function": "tsfel.ecdf_slope",
+      "parameters": {
+        "p_end": 0.75,
+        "p_init": 0.5
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Histogram": {
+      "complexity": "log",
+      "description": "Computes histogram of the signal.",
+      "function": "tsfel.hist",
+      "parameters": {
+        "nbins": 10,
+        "r": 1
+      },
+      "n_features": "nbins",
+      "use": "yes",
+      "tag": ""
+    },
+    "Interquartile range": {
+      "complexity": "constant",
+      "description": "Computes interquartile range of the signal.",
+      "function": "tsfel.interq_range",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Kurtosis": {
+      "complexity": "constant",
+      "description": "Computes kurtosis of the signal.",
+      "function": "tsfel.kurtosis",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Max": {
+      "complexity": "constant",
+      "description": "Computes the maximum value of the signal.",
+      "function": "tsfel.calc_max",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Mean": {
+      "complexity": "constant",
+      "description": "Computes the mean value of the signal.",
+      "function": "tsfel.calc_mean",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": "inertial"
+    },
+    "Mean absolute deviation": {
+      "complexity": "log",
+      "description": "Computes mean absolute deviation of the signal.",
+      "function": "tsfel.mean_abs_deviation",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Median": {
+      "complexity": "constant",
+      "description": "Computes median of the signal.",
+      "function": "tsfel.calc_median",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Median absolute deviation": {
+      "complexity": "constant",
+      "description": "Computes median absolute deviation of the signal.",
+      "function": "tsfel.median_abs_deviation",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Min": {
+      "complexity": "constant",
+      "description": "Computes the minimum value of the signal.",
+      "function": "tsfel.calc_min",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Root mean square": {
+      "complexity": "constant",
+      "description": "Computes root mean square of the signal.",
+      "function": "tsfel.rms",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ["emg", "inertial"]
+    },
+    "Skewness": {
+      "complexity": "constant",
+      "description": "Computes skewness of the signal.",
+      "function": "tsfel.skewness",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Standard deviation": {
+      "complexity": "constant",
+      "description": "Computes standard deviation of the signal.",
+      "function": "tsfel.calc_std",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Variance": {
+      "complexity": "constant",
+      "description": "Computes variance of the signal.",
+      "function": "tsfel.calc_var",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    }
+  },
+  "temporal": {
+    "Absolute energy": {
+      "complexity": "log",
+      "description": "Computes the absolute energy of the signal.",
+      "function": "tsfel.abs_energy",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": "audio"
+    },
+    "Area under the curve": {
+      "complexity": "log",
+      "description": "Computes the area under the curve of the signal computed with trapezoid rule.",
+      "function": "tsfel.auc",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Autocorrelation": {
+      "complexity": "constant",
+      "description": "Computes autocorrelation of the signal.",
+      "function": "tsfel.autocorr",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": "inertial"
+    },
+    "Centroid": {
+      "complexity": "constant",
+      "description": "Computes the centroid along the time axis.",
+      "function": "tsfel.calc_centroid",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Entropy": {
+      "complexity": "log",
+      "description": "Computes the entropy of the signal using the Shannon Entropy.",
+      "function": "tsfel.entropy",
+      "parameters": {
+        "prob": "standard"
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": "eeg"
+    },
+    "Mean absolute diff": {
+      "complexity": "constant",
+      "description": "Computes mean absolute differences of the signal.",
+      "function": "tsfel.mean_abs_diff",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Mean diff": {
+      "complexity": "constant",
+      "description": "Computes mean of differences of the signal.",
+      "function": "tsfel.mean_diff",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Median absolute diff": {
+      "complexity": "constant",
+      "description": "Computes median absolute differences of the signal.",
+      "function": "tsfel.median_abs_diff",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Median diff": {
+      "complexity": "constant",
+      "description": "Computes median of differences of the signal.",
+      "function": "tsfel.median_diff",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Negative turning points": {
+      "complexity": "constant",
+      "description": "Computes number of negative turning points of the signal.",
+      "function": "tsfel.negative_turning",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": "emg"
+    },
+    "Neighbourhood peaks": {
+      "complexity": "constant",
+      "description": "Computes the number of peaks from a defined neighbourhood of the signal.",
+      "function": "tsfel.neighbourhood_peaks",
+      "parameters": {
+        "n": 10
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Peak to peak distance": {
+      "complexity": "constant",
+      "description": "Computes the peak to peak distance.",
+      "function": "tsfel.pk_pk_distance",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Positive turning points": {
+      "complexity": "constant",
+      "description": "Computes number of positive turning points of the signal.",
+      "function": "tsfel.positive_turning",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": "emg"
+    },
+    "Signal distance": {
+      "complexity": "constant",
+      "description": "Computes signal traveled distance.",
+      "function": "tsfel.distance",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Slope": {
+      "complexity": "log",
+      "description": "Computes the slope of the signal by fitting a linear equation to the observed data.",
+      "function": "tsfel.slope",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Sum absolute diff": {
+      "complexity": "constant",
+      "description": "Computes sum of absolute differences of the signal.",
+      "function": "tsfel.sum_abs_diff",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ""
+    },
+    "Total energy": {
+      "complexity": "constant",
+      "description": "Computes the total energy of the signal.",
+      "function": "tsfel.total_energy",
+      "parameters": {
+        "fs": 100
+      },
+      "n_features": 1,
+      "use": "yes",
+      "tag": "audio"
+    },
+    "Zero crossing rate": {
+      "complexity": "constant",
+      "description": "Computes Zero-crossing rate of the signal.",
+      "function": "tsfel.zero_cross",
+      "parameters": "",
+      "n_features": 1,
+      "use": "yes",
+      "tag": ["audio", "emg"]
+    }
+  }
 }

--- a/tsfel/feature_extraction/features.py
+++ b/tsfel/feature_extraction/features.py
@@ -6,6 +6,7 @@ from tsfel.feature_extraction.features_utils import *
 
 
 @set_domain("domain", "temporal")
+@set_domain("tag", "inertial")
 def autocorr(signal):
     """Computes autocorrelation of the signal.
 
@@ -62,6 +63,7 @@ def calc_centroid(signal, fs):
 
 
 @set_domain("domain", "temporal")
+@set_domain("tag", "emg")
 def negative_turning(signal):
     """Computes number of negative turning points of the signal.
 
@@ -85,6 +87,7 @@ def negative_turning(signal):
 
 
 @set_domain("domain", "temporal")
+@set_domain("tag", "emg")
 def positive_turning(signal):
     """Computes number of positive turning points of the signal.
 
@@ -235,6 +238,7 @@ def sum_abs_diff(signal):
 
 
 @set_domain("domain", "temporal")
+@set_domain("tag", ["audio", "emg"])
 def zero_cross(signal):
     """Computes Zero-crossing rate of the signal.
 
@@ -258,6 +262,7 @@ def zero_cross(signal):
 
 
 @set_domain("domain", "temporal")
+@set_domain("tag", "audio")
 def total_energy(signal, fs):
     """Computes the total energy of the signal.
 
@@ -329,6 +334,7 @@ def auc(signal, fs):
 
 
 @set_domain("domain", "temporal")
+@set_domain("tag", "audio")
 def abs_energy(signal):
     """Computes the absolute energy of the signal.
 
@@ -369,6 +375,7 @@ def pk_pk_distance(signal):
 
 
 @set_domain("domain", "temporal")
+@set_domain("tag", "eeg")
 def entropy(signal, prob='standard'):
     """Computes the entropy of the signal using the Shannon Entropy.
 
@@ -574,6 +581,7 @@ def calc_min(signal):
 
 
 @set_domain("domain", "statistical")
+@set_domain("tag", "inertial")
 def calc_mean(signal):
     """Computes mean value of the signal.
 
@@ -654,6 +662,7 @@ def median_abs_deviation(signal):
 
 
 @set_domain("domain", "statistical")
+@set_domain("tag", ["inertial", "emg"])
 def rms(signal):
     """Computes root mean square of the signal.
 
@@ -1010,6 +1019,7 @@ def median_frequency(signal, fs):
 
 
 @set_domain("domain", "spectral")
+@set_domain("tag", "audio")
 def spectral_centroid(signal, fs):
     """Barycenter of the spectrum.
 
@@ -1288,6 +1298,7 @@ def spectral_positive_turning(signal, fs):
 
 
 @set_domain("domain", "spectral")
+@set_domain("tag", "audio")
 def spectral_roll_off(signal, fs):
     """Computes the spectral roll-off of the signal.
 
@@ -1346,6 +1357,7 @@ def spectral_roll_on(signal, fs):
 
 
 @set_domain("domain", "spectral")
+@set_domain("tag", "inertial")
 def human_range_energy(signal, fs):
     """Computes the human range energy ratio.
 
@@ -1383,6 +1395,7 @@ def human_range_energy(signal, fs):
 
 
 @set_domain("domain", "spectral")
+@set_domain("tag", ["audio", "emg"])
 def mfcc(signal, fs, pre_emphasis=0.97, nfft=512, nfilt=40, num_ceps=12, cep_lifter=22):
     """Computes the MEL cepstral coefficients.
 
@@ -1511,6 +1524,7 @@ def fft_mean_coeff(signal, fs, nfreq=256):
 
 
 @set_domain("domain", "spectral")
+@set_domain("tag", "audio")
 def lpcc(signal, n_coeff=12):
     """Computes the linear prediction cepstral coefficients.
 
@@ -1546,6 +1560,7 @@ def lpcc(signal, n_coeff=12):
 
 
 @set_domain("domain", "spectral")
+@set_domain("tag", "eeg")
 def spectral_entropy(signal, fs):
     """Computes the spectral entropy of the signal based on Fourier transform.
 
@@ -1586,6 +1601,7 @@ def spectral_entropy(signal, fs):
 
 
 @set_domain("domain", "spectral")
+@set_domain("tag", "eeg")
 def wavelet_entropy(signal, function=scipy.signal.ricker, widths=np.arange(1, 10)):
     """Computes CWT entropy of the signal.
 
@@ -1624,6 +1640,7 @@ def wavelet_entropy(signal, function=scipy.signal.ricker, widths=np.arange(1, 10
 
 
 @set_domain("domain", "spectral")
+@set_domain("tag", ["eeg", "ecg"])
 def wavelet_abs_mean(signal, function=scipy.signal.ricker, widths=np.arange(1, 10)):
     """Computes CWT absolute mean value of each wavelet scale.
 
@@ -1649,6 +1666,7 @@ def wavelet_abs_mean(signal, function=scipy.signal.ricker, widths=np.arange(1, 1
 
 
 @set_domain("domain", "spectral")
+@set_domain("domain", "eeg")
 def wavelet_std(signal, function=scipy.signal.ricker, widths=np.arange(1, 10)):
     """Computes CWT std value of each wavelet scale.
 
@@ -1674,6 +1692,7 @@ def wavelet_std(signal, function=scipy.signal.ricker, widths=np.arange(1, 10)):
 
 
 @set_domain("domain", "spectral")
+@set_domain("tag", "eeg")
 def wavelet_var(signal, function=scipy.signal.ricker, widths=np.arange(1, 10)):
     """Computes CWT variance value of each wavelet scale.
 
@@ -1699,6 +1718,7 @@ def wavelet_var(signal, function=scipy.signal.ricker, widths=np.arange(1, 10)):
 
 
 @set_domain("domain", "spectral")
+@set_domain("tag", "eeg")
 def wavelet_energy(signal, function=scipy.signal.ricker, widths=np.arange(1, 10)):
     """Computes CWT energy of each wavelet scale.
 

--- a/tsfel/feature_extraction/features_settings.py
+++ b/tsfel/feature_extraction/features_settings.py
@@ -40,7 +40,7 @@ def get_features_by_domain(domain=None, json_path=None):
     """
 
     if json_path is None:
-        json_path = tsfel.__path__[0]+"/feature_extraction/features.json"
+        json_path = tsfel.__path__[0] + "/feature_extraction/features.json"
 
         if domain not in ['statistical', 'temporal', 'spectral', None]:
             raise SystemExit(
@@ -51,6 +51,50 @@ def get_features_by_domain(domain=None, json_path=None):
         return dict_features
     else:
         return {domain: dict_features[domain]}
+
+
+def get_features_by_tag(tag=None, json_path=None):
+    """Creates a dictionary with the features settings by tag.
+
+    Parameters
+    ----------
+    tag : string
+        Available tags: "audio"; "inertial", "ecg"; "eeg"; "emg".
+        If tag equals None then, all available features are returned.
+    json_path : string
+        Directory of json file. Default: package features.json directory
+
+    Returns
+    -------
+    Dict
+        Dictionary with the features settings
+
+    """
+    if json_path is None:
+        json_path = tsfel.__path__[0] + "/feature_extraction/features.json"
+
+        if tag not in ["audio", "inertial", "ecg", "eeg", "emg", None]:
+            raise SystemExit(
+                "No valid tag. Choose: audio, inertial, ecg, eeg, emg or None.")
+
+    features_tag = {}
+    dict_features = load_json(json_path)
+    if tag is None:
+        return dict_features
+    else:
+        for domain in dict_features:
+            features_tag[domain] = {}
+            for feat in dict_features[domain]:
+                if dict_features[domain][feat]["use"] == "no":
+                    continue
+                js_tag = dict_features[domain][feat]["tag"]
+                if isinstance(js_tag, list):
+                    if any([tag in js_t for js_t in js_tag]):
+                        features_tag[domain].update({feat: dict_features[domain][feat]})
+                elif js_tag == tag:
+                    features_tag[domain].update({feat: dict_features[domain][feat]})
+        # to remove empty dicts
+        return dict([[d, features_tag[d]] for d in list(features_tag.keys()) if bool(features_tag[d])])
 
 
 def get_number_features(dict_features):
@@ -80,6 +124,6 @@ def get_number_features(dict_features):
                 if isinstance(n_feat_param, int):
                     number_features += n_feat_param
                 else:
-                    number_features += eval("len("+n_feat_param+")")
+                    number_features += eval("len(" + n_feat_param + ")")
 
     return number_features

--- a/tsfel/feature_extraction/features_settings.py
+++ b/tsfel/feature_extraction/features_settings.py
@@ -76,7 +76,6 @@ def get_features_by_tag(tag=None, json_path=None):
         if tag not in ["audio", "inertial", "ecg", "eeg", "emg", None]:
             raise SystemExit(
                 "No valid tag. Choose: audio, inertial, ecg, eeg, emg or None.")
-
     features_tag = {}
     dict_features = load_json(json_path)
     if tag is None:
@@ -87,13 +86,17 @@ def get_features_by_tag(tag=None, json_path=None):
             for feat in dict_features[domain]:
                 if dict_features[domain][feat]["use"] == "no":
                     continue
-                js_tag = dict_features[domain][feat]["tag"]
-                if isinstance(js_tag, list):
-                    if any([tag in js_t for js_t in js_tag]):
+                # Check if tag is defined
+                try:
+                    js_tag = dict_features[domain][feat]["tag"]
+                    if isinstance(js_tag, list):
+                        if any([tag in js_t for js_t in js_tag]):
+                            features_tag[domain].update({feat: dict_features[domain][feat]})
+                    elif js_tag == tag:
                         features_tag[domain].update({feat: dict_features[domain][feat]})
-                elif js_tag == tag:
-                    features_tag[domain].update({feat: dict_features[domain][feat]})
-        # to remove empty dicts
+                except KeyError:
+                    continue
+        # To remove empty dicts
         return dict([[d, features_tag[d]] for d in list(features_tag.keys()) if bool(features_tag[d])])
 
 

--- a/tsfel/utils/add_personal_features.py
+++ b/tsfel/utils/add_personal_features.py
@@ -47,8 +47,9 @@ def add_feature_json(features_path, json_path):
             # Access to personal features.json
             feat_json = load_json(json_path)
 
-            # Assign domain
+            # Assign domain and tag
             domain = getattr(f, "domain", None)
+            tag = getattr(f, "tag", None)
 
             # Feature specifications
             # Description
@@ -92,6 +93,10 @@ def add_feature_json(features_path, json_path):
                 feat_json[domain][fname] = new_feature
             except KeyError:
                 feat_json[domain] = {fname: new_feature}
+
+            # Insert tag if it is declared
+            if tag is not None:
+                feat_json[domain][fname]['tag'] = tag
 
             # Write new feature on json file
             with open(json_path, "w") as fout:


### PR DESCRIPTION
Added a new feature setting to extract features according to the type of signal. Thus, all features, in features.json, present now a new item denoted as "tag". Some features are already tagged according to information on literature. One feature can have one or more tags.

Current tags are: audio, inertial, eeg, ecg and emg. 

Tests for the implementation are also provided.