### PR TITLE
Fix ResourceWarning: unclosed file

### DIFF
--- a/tsfel/feature_extraction/features_settings.py
+++ b/tsfel/feature_extraction/features_settings.py
@@ -18,7 +18,7 @@ def load_json(json_path):
     Dict
         Dictionary
     """
-    
+
     with open(json_path) as json_file:
         return json.load(json_file)
 

--- a/tsfel/feature_extraction/features_settings.py
+++ b/tsfel/feature_extraction/features_settings.py
@@ -18,8 +18,9 @@ def load_json(json_path):
     Dict
         Dictionary
     """
-
-    return json.load(open(json_path))
+    
+    with open(json_path) as json_file:
+        return json.load(json_file)
 
 
 def get_features_by_domain(domain=None, json_path=None):


### PR DESCRIPTION
I noticed the following warning being printed by python when using TSFEL:

```
ResourceWarning: unclosed file <_io.TextIOWrapper name='/usr/local/lib/python3.11/site-packages/tsfel/feature_extraction/features.json' mode='r' encoding='UTF-8'>
```

The reason seems to be in the load_json function, where the json file is opened but never explicitly closed.

Hereby a quick proposed fix.