### PR TITLE
Fix locals issue on py3.13

### DIFF
--- a/tsfel/feature_extraction/calc_features.py
+++ b/tsfel/feature_extraction/calc_features.py
@@ -18,7 +18,6 @@ from tsfel.utils.progress_bar import display_progress_bar, progress_bar_notebook
 from tsfel.utils.signal_processing import merge_time_series, signal_window_splitter
 
 import importlib
-features_mod = importlib.import_module('tsfel.feature_extraction.features')
 
 def dataset_features_extractor(main_directory, feat_dict, verbose=1, **kwargs):
     r"""Extracts features from a dataset.
@@ -471,6 +470,8 @@ def calc_window_features(
             out = None
 
         i_feat = -1
+
+    features_mod = importlib.import_module('tsfel.feature_extraction.features')
 
     for _type in domain:
         domain_feats = config[_type].keys()

--- a/tsfel/feature_extraction/calc_features.py
+++ b/tsfel/feature_extraction/calc_features.py
@@ -17,6 +17,8 @@ from IPython.display import display
 from tsfel.utils.progress_bar import display_progress_bar, progress_bar_notebook
 from tsfel.utils.signal_processing import merge_time_series, signal_window_splitter
 
+import importlib
+features_mod = importlib.import_module('tsfel.feature_extraction.features')
 
 def dataset_features_extractor(main_directory, feat_dict, verbose=1, **kwargs):
     r"""Extracts features from a dataset.
@@ -507,7 +509,7 @@ def calc_window_features(
 
                 # Eval feature results
                 if single_axis:
-                    eval_result = locals()[func_total](
+                    eval_result = getattr(features_mod, func_total)(
                         window,
                         **parameters_total,
                     )
@@ -515,7 +517,7 @@ def calc_window_features(
 
                 for ax in range(len(header_names)):
                     sig_ax = window if single_axis else window[:, ax]
-                    eval_result_ax = locals()[func_total](sig_ax, **parameters_total)
+                    eval_result_ax = getattr(features_mod, func_total)(sig_ax, **parameters_total)
 
                     # Function returns more than one element
                     if isinstance(eval_result_ax, tuple):


### PR DESCRIPTION
With the behavior change on py3.13, the locals()[func_total] in calc_features.py become to raises KeyError.
This pull request fixes the issue with the use of "importlib". 