### PR TITLE
Dynamic rounding for low frequency signals

### DIFF
--- a/tsfel/feature_extraction/features.py
+++ b/tsfel/feature_extraction/features.py
@@ -2,6 +2,7 @@ import warnings
 
 import scipy
 from statsmodels.tsa.stattools import acf
+import numpy as np
 
 from tsfel.constants import FEATURES_MIN_SIZE
 from tsfel.feature_extraction.features_utils import *
@@ -1549,7 +1550,8 @@ def spectrogram_mean_coeff(signal, fs, bins=32):
 
     frequencies, _, Sxx = scipy.signal.spectrogram(signal, fs, nperseg=bins * 2 - 2)
     Sxx_mean = Sxx.mean(1)
-    f_keys = np.round(frequencies, 2).astype(str)
+    f_keys=round_distinct(frequencies)
+    # f_keys = np.round(frequencies, 2).astype(str)
 
     return {"names": [f + "Hz" for f in f_keys], "values": Sxx_mean}
 
@@ -1695,7 +1697,8 @@ def wavelet_abs_mean(signal, fs, wavelet="mexh", max_width=10):
     widths = np.arange(1, max_width)
 
     coeffs, frequencies = continuous_wavelet_transform(signal=signal, fs=fs, wavelet=wavelet, widths=widths)
-    f_keys = np.round(frequencies, 2).astype(str)
+    f_keys=round_distinct(frequencies)
+    # f_keys = np.round(frequencies, 2).astype(str)
 
     return {"names": [f + "Hz" for f in f_keys], "values": np.abs(np.mean(coeffs, axis=1))}
 
@@ -1725,7 +1728,8 @@ def wavelet_std(signal, fs, wavelet="mexh", max_width=10):
     widths = np.arange(1, max_width)
 
     coeffs, frequencies = continuous_wavelet_transform(signal=signal, fs=fs, wavelet=wavelet, widths=widths)
-    f_keys = np.round(frequencies, 2).astype(str)
+    f_keys=round_distinct(frequencies)
+    # f_keys = np.round(frequencies, 2).astype(str)
 
     return {"names": [f + "Hz" for f in f_keys], "values": np.std(coeffs, axis=1)}
 
@@ -1755,7 +1759,8 @@ def wavelet_var(signal, fs, wavelet="mexh", max_width=10):
     widths = np.arange(1, max_width)
 
     coeffs, frequencies = continuous_wavelet_transform(signal=signal, fs=fs, wavelet=wavelet, widths=widths)
-    f_keys = np.round(frequencies, 2).astype(str)
+    f_keys=round_distinct(frequencies)
+    # f_keys = np.round(frequencies, 2).astype(str)
 
     return {"names": [f + "Hz" for f in f_keys], "values": np.var(coeffs, axis=1)}
 
@@ -1788,7 +1793,8 @@ def wavelet_energy(signal, fs, wavelet="mexh", max_width=10):
     widths = np.arange(1, max_width)
 
     coeffs, frequencies = continuous_wavelet_transform(signal=signal, fs=fs, wavelet=wavelet, widths=widths)
-    f_keys = np.round(frequencies, 2).astype(str)
+    f_keys=round_distinct(frequencies)
+    # f_keys = np.round(frequencies, 2).astype(str)
 
     return {"names": [f + "Hz" for f in f_keys], "values": np.sqrt(np.sum(coeffs**2, axis=1) / np.shape(coeffs)[1])}
 

--- a/tsfel/feature_extraction/features.py
+++ b/tsfel/feature_extraction/features.py
@@ -2,7 +2,6 @@ import warnings
 
 import scipy
 from statsmodels.tsa.stattools import acf
-import numpy as np
 
 from tsfel.constants import FEATURES_MIN_SIZE
 from tsfel.feature_extraction.features_utils import *

--- a/tsfel/feature_extraction/features_utils.py
+++ b/tsfel/feature_extraction/features_utils.py
@@ -631,7 +631,7 @@ def find_plateau(y, threshold=0.1, consecutive_points=5):
     # No plateau found
     return len(y)
 
-def round_distinct(s: np.ndarray) -> int:
+def round_distinct(s: np.ndarray) -> np.ndarray:
     low_ind=s[1].astype(str).replace("0","e").replace(".","e").count("e")+1
     if low_ind <=310:
         ValueError(f"Frequency {s[1]} Hz too small for floating-point variables.")

--- a/tsfel/feature_extraction/features_utils.py
+++ b/tsfel/feature_extraction/features_utils.py
@@ -630,3 +630,12 @@ def find_plateau(y, threshold=0.1, consecutive_points=5):
 
     # No plateau found
     return len(y)
+
+def round_distinct(s: np.ndarray) -> int:
+    low_ind=s[1].astype(str).replace("0","e").replace(".","e").count("e")+1
+    if low_ind <=310:
+        ValueError(f"Frequency {s[1]} Hz too small for floating-point variables.")
+    for i in range(low_ind,310):
+        s_sf=np.round(s, i)
+        if len(set(s_sf)) == len(s):
+            return np.round(s, i).astype(str)


### PR DESCRIPTION
Hi, I've also run into this issue #183, 
I did some digging, and the issue, at least for my toy data, seems to occur when using `fs <= 5`. Below is an example of the toy data and the parameters that are failing: 

```['0_Spectrogram mean coefficient_0.0Hz', '0_Spectrogram mean coefficient_0.01Hz', '0_Wavelet absolute mean_0.0Hz', '0_Wavelet energy_0.0Hz', '0_Wavelet standard deviation_0.0Hz', '0_Wavelet variance_0.0Hz']```

which are derived from the following code:
```
import pandas as pd
import numpy as np
import tsfel

cfg=tsfel.get_features_by_domain()
ts=np.array([2., 3., 4., 5., 4., 3., 2., 1., 2., 3., 4., 5., 4., 3., 2., 1., 2.])
tsfel.time_series_features_extractor(cfg,ts,fs=1/60)
``` 

The problem comes from the hardcoded minimum rounding of the low frequencies (below 5) returned by `scipy.signal.spectrogram` and `continuous_wavelet_transform`. If they are below 5, rounding to 2 will lead to some of the column names being the same, e.g. `[col_0.00Hz, col_0.00Hz]`. I wrote a quick function to automatically work out the optimal number of significant figures and put this in `feature_utils.py` and updated `features`. 

This is the function: 
```
def round_distinct(s: np.ndarray) -> np.ndarray:
    low_ind=s[1].astype(str).replace("0","e").replace(".","e").count("e")+1
    if low_ind <=310:
        ValueError(f"Frequency {s[1]} Hz too small for floating-point variables.")
    for i in range(low_ind,310):
        s_sf=np.round(s, i)
        if len(set(s_sf)) == len(s):
            return np.round(s, i).astype(str)
```
As a note, I used s[1] instead of s[0] in case the lowest frequency for some reason is 0. But this can be changed if it's wrong.
This is not necessarily an optimal function, but it should work ok. 

I have not written tests as I don't know how this would be integrated into the current testing scripts.